### PR TITLE
AF-1782 - 2. ts-exporter Annotation Processor

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,14 @@ Getting started
 --
 #### 1. Building
 
+##### 1. Core
 1. `cd packages/core`
 2. `yarn run init && yarn run build`
 
 Build results will appear on `packages/core/dist`
+
+##### 1. ts-exporter
+1. `cd packages/ts-exporter`
+2. `mvn clean install`
+
+Build results will appear on `packages/ts-exporter/target`

--- a/packages/ts-exporter/README.md
+++ b/packages/ts-exporter/README.md
@@ -5,7 +5,7 @@ This module provides a Java Annotation Processor to generate and locally publish
 ##Building
 mvn clean install
 
-#Usage
+##Usage
 Simply add its dependency on an existing Maven module and the Annotation Processor present will scan for `@Remote`- and `@Portable`-annotated classes. 
 
 For `lib` modules, files containing the Full Qualified Class Names (fqcn) of the annotated types will be created.

--- a/packages/ts-exporter/README.md
+++ b/packages/ts-exporter/README.md
@@ -1,11 +1,14 @@
-#ts-exporter
+ts-exporter
+===
 
 This module provides a Java Annotation Processor to generate and locally publish TypeScript packages containing the code necessary to interact with the Errai Bus. It works both for RPC and Events.
 
-##Building
-mvn clean install
+Building
+==
+Run `mvn clean install` on this directory.
 
-##Usage
+Usage
+===
 Simply add its dependency on an existing Maven module and the Annotation Processor present will scan for `@Remote`- and `@Portable`-annotated classes. 
 
 For `lib` modules, files containing the Full Qualified Class Names (fqcn) of the annotated types will be created.

--- a/packages/ts-exporter/README.md
+++ b/packages/ts-exporter/README.md
@@ -1,0 +1,74 @@
+#ts-exporter
+
+This module provides a Java Annotation Processor to generate and locally publish TypeScript packages containing the code necessary to interact with the Errai Bus. It works both for RPC and Events.
+
+##Building
+mvn clean install
+
+#Usage
+Simply add its dependency on an existing Maven module and the Annotation Processor present will scan for `@Remote`- and `@Portable`-annotated classes. 
+
+For `lib` modules, files containing the Full Qualified Class Names (fqcn) of the annotated types will be created.
+ 
+> **NOTE:** `lib` modules don't need any special configuration. Just the dependency will suffice.
+
+For `app` modules, TypeScript code will be generated and published to your local NPM registry running on `http://localhost:4873`. `@Portable` classes will be present on `@kiegroup-ts-generated/[my-module]` and `@Remote` ones will be on `@kiegroup-ts-generated/[my-module]-rpc`. We recommend using [verdaccio](https://github.com/verdaccio/verdaccio) as your local npm registry. To install it simply run `npm install -g verdaccio`. To run it, simply run `verdaccio`. The `app` module must have at least one class annotated with `@EntryPoint`, `@Portable`, or `@Remote`.
+
+> **NOTE:** `app` modules require a special configuration to actually generate and lcoally publish the generated TypeScript code:
+
+>> **ts-exporter-output-dir** must be configured with the directory where the root of generated code will be.
+
+>> **ts-exporter** must be set to "export".
+
+The following Maven profile configuration is recommended.
+```xml
+    <profile>
+      <id>ts-exporter-build</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>properties-maven-plugin</artifactId>
+            <version>1.0.0</version>
+            <executions>
+              <execution>
+                <id>set-ts-exporter-all</id>
+                <phase>validate</phase>
+                <goals>
+                  <goal>set-system-properties</goal>
+                </goals>
+                <configuration>
+                  <properties>
+                    <property>
+                      <name>ts-exporter-output-dir</name>
+                      <value>${project.build.directory}</value>
+                    </property>
+                    <property>
+                      <name>ts-exporter</name>
+                      <value>export</value>
+                    </property>
+                  </properties>
+                </configuration>
+              </execution>
+              <execution>
+                <id>set-ts-exporter-none</id>
+                <phase>prepare-package</phase>
+                <goals>
+                  <goal>set-system-properties</goal>
+                </goals>
+                <configuration>
+                  <properties>
+                    <property>
+                      <name>ts-exporter</name>
+                      <value>default</value>
+                    </property>
+                  </properties>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+```
+

--- a/packages/ts-exporter/README.md
+++ b/packages/ts-exporter/README.md
@@ -11,11 +11,13 @@ Usage
 ===
 Simply add its dependency on an existing Maven module and the Annotation Processor present will scan for `@Remote`- and `@Portable`-annotated classes. 
 
-For `lib` modules, files containing the Full Qualified Class Names (fqcn) of the annotated types will be created.
+ - For `lib` modules, files containing the Full Qualified Class Names (fqcn) of the annotated types will be created.
  
 > **NOTE:** `lib` modules don't need any special configuration. Just the dependency will suffice.
 
-For `app` modules, TypeScript code will be generated and published to your local NPM registry running on `http://localhost:4873`. `@Portable` classes will be present on `@kiegroup-ts-generated/[my-module]` and `@Remote` ones will be on `@kiegroup-ts-generated/[my-module]-rpc`. We recommend using [verdaccio](https://github.com/verdaccio/verdaccio) as your local npm registry. To install it simply run `npm install -g verdaccio`. To run it, simply run `verdaccio`. The `app` module must have at least one class annotated with `@EntryPoint`, `@Portable`, or `@Remote`.
+- For `app` modules, TypeScript code will be generated and published to your local NPM registry running on `http://localhost:4873`. `@Portable` classes will be present on `@kiegroup-ts-generated/[my-module]` and `@Remote` ones will be on `@kiegroup-ts-generated/[my-module]-rpc`. 
+
+> **NOTE:** We recommend using [verdaccio](https://github.com/verdaccio/verdaccio) as your local npm registry. To install it simply run `npm install -g verdaccio`. To run it, simply run `verdaccio`. The `app` module must have at least one class annotated with `@EntryPoint`, `@Portable`, or `@Remote`.
 
 > **NOTE:** `app` modules require a special configuration to actually generate and lcoally publish the generated TypeScript code:
 

--- a/packages/ts-exporter/README.md
+++ b/packages/ts-exporter/README.md
@@ -18,12 +18,12 @@ Simply add its dependency on an existing Maven module and the Annotation Process
 - For `app` modules, TypeScript code will be generated and published to your local NPM registry running on `http://localhost:4873`. `@Portable` classes will be present on `@kiegroup-ts-generated/[my-module]` and `@Remote` ones will be on `@kiegroup-ts-generated/[my-module]-rpc`. 
 
 > **NOTE:** We recommend using [verdaccio](https://github.com/verdaccio/verdaccio) as your local npm registry. To install it simply run `npm install -g verdaccio`. To run it, simply run `verdaccio`. The `app` module must have at least one class annotated with `@EntryPoint`, `@Portable`, or `@Remote`.
-
+>
 > **NOTE:** `app` modules require a special configuration to actually generate and lcoally publish the generated TypeScript code:
-
->> **ts-exporter-output-dir** must be configured with the directory where the root of generated code will be.
-
->> **ts-exporter** must be set to "export".
+>
+>-  **ts-exporter-output-dir** must be configured with the directory where the root of generated code will be.
+>
+> - **ts-exporter** must be set to "export".
 
 The following Maven profile configuration is recommended.
 ```xml

--- a/packages/ts-exporter/pom.xml
+++ b/packages/ts-exporter/pom.xml
@@ -73,6 +73,56 @@
         </configuration>
       </plugin>
     </plugins>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.pitest</groupId>
+          <artifactId>pitest-maven</artifactId>
+          <version>1.4.5</version>
+          <configuration>
+            <reportsDirectory>target/pit-reports</reportsDirectory>
+            <timestampedReports>true</timestampedReports>
+            <timeoutConstant>1000</timeoutConstant>
+            <mutators>
+              <!-- See http://pitest.org/quickstart/mutators/ -->
+              <mutator>DEFAULTS</mutator>
+              <mutator>NON_VOID_METHOD_CALLS</mutator>
+              <mutator>REMOVE_CONDITIONALS</mutator>
+            </mutators>
+            <avoidCallsTo>java.lang.StringBuilder</avoidCallsTo>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
+
+  <profiles>
+    <profile>
+      <!-- Mutation coverage disabled by default (use -Dmutation-coverage to activate it) -->
+      <id>mutation-coverage</id>
+      <activation>
+        <property>
+          <name>mutation-coverage</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.pitest</groupId>
+            <artifactId>pitest-maven</artifactId>
+            <executions>
+              <execution>
+                <id>default-pitest</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>mutationCoverage</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
 </project>

--- a/packages/ts-exporter/pom.xml
+++ b/packages/ts-exporter/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.appformer</groupId>
+    <artifactId>ts-exporter</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>AppFormer JS :: API TypeScript Exporter</name>
+    <description>TypeScript API exporter for AppFormer.js</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.testing.compile</groupId>
+            <artifactId>compile-testing</artifactId>
+            <version>0.15</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.3.0</version>
+            <scope>test</scope>
+        </dependency>
+      <dependency>
+        <groupId>com.google.code.gson</groupId>
+        <artifactId>gson</artifactId>
+        <version>2.8.5</version>
+      </dependency>
+      <dependency>
+        <artifactId>guava</artifactId>
+        <groupId>com.google.guava</groupId>
+        <version>15.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.reflections</groupId>
+        <artifactId>reflections</artifactId>
+        <version>0.9.11</version>
+      </dependency>
+    </dependencies>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                    <proc>none</proc>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/packages/ts-exporter/pom.xml
+++ b/packages/ts-exporter/pom.xml
@@ -17,61 +17,62 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+  <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.appformer</groupId>
-    <artifactId>ts-exporter</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <packaging>jar</packaging>
+  <groupId>org.appformer</groupId>
+  <artifactId>ts-exporter</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
 
-    <name>AppFormer JS :: API TypeScript Exporter</name>
-    <description>TypeScript API exporter for AppFormer.js</description>
+  <name>AppFormer JS :: API TypeScript Exporter</name>
+  <description>TypeScript API exporter for AppFormer.js</description>
 
-    <dependencies>
-        <dependency>
-            <groupId>com.google.testing.compile</groupId>
-            <artifactId>compile-testing</artifactId>
-            <version>0.15</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <version>5.3.0</version>
-            <scope>test</scope>
-        </dependency>
-      <dependency>
-        <groupId>com.google.code.gson</groupId>
-        <artifactId>gson</artifactId>
-        <version>2.8.5</version>
-      </dependency>
-      <dependency>
-        <artifactId>guava</artifactId>
-        <groupId>com.google.guava</groupId>
-        <version>15.0</version>
-      </dependency>
-      <dependency>
-        <groupId>org.reflections</groupId>
-        <artifactId>reflections</artifactId>
-        <version>0.9.11</version>
-      </dependency>
-    </dependencies>
+  <dependencies>
+    <dependency>
+      <groupId>com.google.testing.compile</groupId>
+      <artifactId>compile-testing</artifactId>
+      <version>0.15</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>5.3.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.8.5</version>
+    </dependency>
+    <dependency>
+      <artifactId>guava</artifactId>
+      <groupId>com.google.guava</groupId>
+      <version>15.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.reflections</groupId>
+      <artifactId>reflections</artifactId>
+      <version>0.9.11</version>
+    </dependency>
+  </dependencies>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
 
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                    <proc>none</proc>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.0</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+          <proc>none</proc>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 
 </project>

--- a/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/Main.java
+++ b/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/Main.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.Filer;
+import javax.annotation.processing.Messager;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.util.Elements;
+import javax.lang.model.util.Types;
+
+import org.uberfire.jsbridge.tsexporter.config.Configuration;
+import org.uberfire.jsbridge.tsexporter.decorators.DecoratorStore;
+
+import static java.lang.Boolean.getBoolean;
+import static java.lang.System.currentTimeMillis;
+import static java.lang.System.getProperty;
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toMap;
+import static javax.tools.Diagnostic.Kind.ERROR;
+import static javax.tools.StandardLocation.CLASS_OUTPUT;
+import static org.uberfire.jsbridge.tsexporter.Main.ENTRY_POINT;
+import static org.uberfire.jsbridge.tsexporter.Main.PORTABLE;
+import static org.uberfire.jsbridge.tsexporter.Main.REMOTE;
+
+@SupportedSourceVersion(SourceVersion.RELEASE_8)
+@SupportedAnnotationTypes({REMOTE, PORTABLE, ENTRY_POINT})
+public class Main extends AbstractProcessor {
+
+    static final String REMOTE = "org.jboss.errai.bus.server.annotations.Remote";
+    static final String PORTABLE = "org.jboss.errai.common.client.api.annotations.Portable";
+    static final String ENTRY_POINT = "org.jboss.errai.ioc.client.api.EntryPoint";
+    static final String TS_EXPORTER_PACKAGE = "org.appformer.tsexporter.exports";
+
+    public static Types types;
+    public static Elements elements;
+    public static Messager messager;
+    public static Filer filer;
+
+    private static final List<Element> seenPortableTypes = new ArrayList<>();
+    private static final List<Element> seenRemoteInterfaces = new ArrayList<>();
+
+    @Override
+    public synchronized void init(final ProcessingEnvironment processingEnv) {
+        super.init(processingEnv);
+        Main.types = processingEnv.getTypeUtils();
+        Main.elements = processingEnv.getElementUtils();
+        Main.messager = processingEnv.getMessager();
+        Main.filer = processingEnv.getFiler();
+    }
+
+    @Override
+    public boolean process(final Set<? extends TypeElement> annotations,
+                           final RoundEnvironment roundEnv) {
+
+        try {
+            if ("skip".equals(getProperty("ts-exporter"))) {
+                System.out.println("TypeScript exporter is not activated.");
+                return false;
+            }
+
+            process(roundEnv, annotations.stream().collect(toMap(identity(), roundEnv::getElementsAnnotatedWith)));
+            return false;
+        } catch (final Exception e) {
+            e.printStackTrace();
+            processingEnv.getMessager().printMessage(ERROR, "Error on TypeScript exporter.");
+            return false;
+        }
+    }
+
+    private void process(final RoundEnvironment roundEnv,
+                         final Map<TypeElement, Set<? extends Element>> typesByAnnotations) {
+
+        if (!roundEnv.processingOver() && !roundEnv.errorRaised()) {
+            typesByAnnotations.forEach((annotation, classes) -> {
+                if (REMOTE.equals(annotation.getQualifiedName().toString())) {
+                    seenRemoteInterfaces.addAll(classes);
+                } else if (PORTABLE.equals(annotation.getQualifiedName().toString())) {
+                    seenPortableTypes.addAll(classes);
+                } else if (ENTRY_POINT.equals(annotation.getQualifiedName().toString())) {
+                    System.out.println("EntryPoint detected.");
+                } else {
+                    throw new RuntimeException("Unsupported annotation type.");
+                }
+            });
+        } else {
+
+            writeExportFile(seenPortableTypes, "portables.tsexporter");
+            writeExportFile(seenRemoteInterfaces, "remotes.tsexporter");
+
+            if (getBoolean("ts-exporter.skip")) {
+                System.out.println("TypeScript exporter is skipped.");
+                return;
+            }
+
+            if ("export".equals(getProperty("ts-exporter"))) {
+                final long start = currentTimeMillis();
+                System.out.println("Generating all TypeScript npm packages...");
+
+                final String version = "1.0.0"; //TODO: Read from System property or something
+                final Configuration config = new Configuration();
+                final TsCodegenResult result = new TsCodegen(version, new DecoratorStore(config)).generate();
+
+                final TsCodegenWriter writer = new TsCodegenWriter(config, result);
+                writer.write();
+
+                final TsCodegenBuilder builder = new TsCodegenBuilder(writer.getOutputDir());
+                builder.build();
+
+                final TsCodegenLibBundler bundler = new TsCodegenLibBundler(config, writer);
+                bundler.bundle();
+
+                System.out.println("TypeScript exporter has successfully run. (" + (currentTimeMillis() - start) + "ms)");
+            } else {
+                System.out.println("TypeScript exporter will not run because ts-exporter property is not set to \"export\".");
+            }
+        }
+    }
+
+    private void writeExportFile(final List<Element> elements,
+                                 final String fileName) {
+
+        final String contents = elements.stream()
+                .map(element -> ((TypeElement) element).getQualifiedName().toString())
+                .distinct()
+                .collect(joining("\n"));
+
+        try (final Writer writer = filer.createResource(CLASS_OUTPUT, TS_EXPORTER_PACKAGE, fileName).openWriter()) {
+            System.out.println("Saving export file: " + fileName + "... ");
+            writer.write(contents);
+        } catch (final IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/TsCodegen.java
+++ b/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/TsCodegen.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.Scanner;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+
+import org.uberfire.jsbridge.tsexporter.decorators.DecoratorStore;
+import org.uberfire.jsbridge.tsexporter.dependency.DependencyGraph;
+import org.uberfire.jsbridge.tsexporter.model.NpmPackageGenerated;
+import org.uberfire.jsbridge.tsexporter.model.PojoTsClass;
+import org.uberfire.jsbridge.tsexporter.model.RpcCallerTsClass;
+import org.uberfire.jsbridge.tsexporter.model.TsClass;
+import org.uberfire.jsbridge.tsexporter.util.Utils;
+
+import static java.util.Arrays.stream;
+import static java.util.Collections.list;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
+import static java.util.stream.Stream.concat;
+import static java.util.stream.Stream.empty;
+import static org.uberfire.jsbridge.tsexporter.Main.TS_EXPORTER_PACKAGE;
+import static org.uberfire.jsbridge.tsexporter.Main.elements;
+import static org.uberfire.jsbridge.tsexporter.model.NpmPackage.Type.FINAL;
+import static org.uberfire.jsbridge.tsexporter.model.NpmPackage.Type.RAW;
+import static org.uberfire.jsbridge.tsexporter.model.NpmPackage.Type.UNDECORATED;
+import static org.uberfire.jsbridge.tsexporter.util.Utils.distinctBy;
+import static org.uberfire.jsbridge.tsexporter.util.Utils.get;
+import static org.uberfire.jsbridge.tsexporter.util.Utils.getResources;
+
+public class TsCodegen {
+
+    private final String version;
+    private final String appformerJsVersion;
+    private final DecoratorStore decoratorStore;
+
+    public TsCodegen(final String version,
+                     final DecoratorStore decoratorStore) {
+
+        this.version = version;
+        this.appformerJsVersion = "1.0.0"; //FIXME: Change that
+        this.decoratorStore = decoratorStore;
+    }
+
+    public TsCodegenResult generate() {
+        return new TsCodegenResult(version,
+                                   appformerJsVersion,
+                                   decoratorStore,
+                                   concat(generateRaw().stream(),
+                                          generateNonRaw().stream()).collect(toSet()));
+    }
+
+    private Set<NpmPackageGenerated> generateRaw() {
+        final DecoratorStore decoratorStore = this.decoratorStore.ignoringForCurrentNpmPackage();
+        final Stream<Element> allDecoratedPortableTypes = findAllPortableTypes()
+                .filter(e -> {
+                    final PojoTsClass pojoTsClass = new PojoTsClass((DeclaredType) e.asType(), decoratorStore);
+                    return decoratorStore.hasDecoratorsFor(pojoTsClass.getUnscopedNpmPackageName());
+                });
+
+        return new DependencyGraph(allDecoratedPortableTypes, decoratorStore)
+                .vertices().parallelStream()
+                .map(DependencyGraph.Vertex::getPojoClass)
+                .filter(distinctBy(tsClass -> tsClass.getType().toString()))
+                .collect(groupingBy(TsClass::getNpmPackageName, toSet()))
+                .entrySet()
+                .parallelStream()
+                .flatMap(e -> decoratorStore.hasDecoratorsFor(get(-1, e.getKey().split("/")))
+                        ? Stream.of(new NpmPackageGenerated(e.getKey(), e.getValue(), version, RAW))
+                        : Stream.empty())
+                .collect(toSet());
+    }
+
+    private Set<NpmPackageGenerated> generateNonRaw() {
+
+        final DependencyGraph dependencyGraph = new DependencyGraph(findAllPortableTypes(), decoratorStore);
+
+        final Set<? extends TsClass> rpcTsClasses = readExportedTypesFrom("remotes.tsexporter").stream()
+                .map(element -> new RpcCallerTsClass(element, dependencyGraph, decoratorStore))
+                .peek(TsClass::toSource)
+                .collect(toSet());
+
+        final Stream<TsClass> tsClasses = concat(
+                dependencyGraph.vertices().parallelStream().map(DependencyGraph.Vertex::getPojoClass),
+                rpcTsClasses.parallelStream());
+
+        return tsClasses
+                .filter(distinctBy(tsClass -> tsClass.getType().toString()))
+                .collect(groupingBy(TsClass::getNpmPackageName, toSet()))
+                .entrySet()
+                .parallelStream()
+                .map(e -> decoratorStore.hasDecoratorsFor(get(-1, e.getKey().split("/")))
+                        ? new NpmPackageGenerated(e.getKey(), e.getValue(), version, FINAL)
+                        : new NpmPackageGenerated(e.getKey(), e.getValue(), version, UNDECORATED))
+                .collect(toSet());
+    }
+
+    private Stream<Element> findAllPortableTypes() {
+        return concat(readExportedTypesFrom("portables.tsexporter").stream(),
+                      getClassesFromErraiAppPropertiesFiles().stream());
+    }
+
+    private List<? extends Element> getClassesFromErraiAppPropertiesFiles() {
+        return list(getResources("META-INF/ErraiApp.properties")).stream()
+                .map(Utils::loadPropertiesFile)
+                .map(properties -> Optional.ofNullable(properties.getProperty("errai.marshalling.serializableTypes")))
+                .filter(Optional::isPresent).map(Optional::get)
+                .flatMap(serializableTypes -> stream(serializableTypes.split(" \n?")))
+                .map(fqcn -> elements.getTypeElement(fqcn.trim().replace("$", ".")))
+                .collect(toList());
+    }
+
+    private List<TypeElement> readExportedTypesFrom(final String exportFileName) {
+        return readAllExportFiles(exportFileName).stream()
+                .map(elements::getTypeElement)
+                .collect(toList());
+    }
+
+    private List<String> readAllExportFiles(final String fileName) {
+        return list(getResources(TS_EXPORTER_PACKAGE.replace(".", "/") + "/" + fileName)).stream()
+                .flatMap(url -> {
+                    try {
+                        final Scanner scanner = new Scanner(url.openStream()).useDelimiter("\\A");
+                        return scanner.hasNext() ? stream(scanner.next().split("\n")) : empty();
+                    } catch (final IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                }).collect(toList());
+    }
+}

--- a/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/TsCodegenBuilder.java
+++ b/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/TsCodegenBuilder.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter;
+
+import static java.lang.String.format;
+
+public class TsCodegenBuilder {
+
+    private final String baseDir;
+
+    public TsCodegenBuilder(final String baseDir) {
+        this.baseDir = baseDir;
+    }
+
+    public void build() {
+        System.out.println("Building npm packages..");
+        System.out.println("Verdaccio installed at:");
+        if (bash("which verdaccio") != 0) {
+            throw new RuntimeException("Verdaccio is not installed.");
+        }
+
+        System.out.println("Checking if Verdaccio is up..");
+        if (bash("test -z `ps -ef | awk '/[V]erdaccio/{print $2}'`") == 0) {
+            throw new RuntimeException("Verdaccio is not running.");
+        }
+
+        System.out.println("Building packages..");
+        if (bash(format("cd %s && yarn run build:ts-exporter", baseDir)) != 0) {
+            throw new RuntimeException("Build failed. Scroll up to see the logs.");
+        }
+    }
+
+    private int bash(final String command) {
+
+        System.out.println("--> bash: " + command);
+
+        try {
+            final ProcessBuilder processBuilder = new ProcessBuilder("bash", "-c", command);
+            processBuilder.inheritIO();
+            final Process process = processBuilder.start();
+            process.waitFor();
+            return process.exitValue();
+        } catch (final Exception e) {
+            throw new RuntimeException(format("Something failed while running command [ %s ]", command));
+        }
+    }
+}

--- a/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/TsCodegenLibBundler.java
+++ b/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/TsCodegenLibBundler.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.uberfire.jsbridge.tsexporter.config.AppFormerComponentsRegistry;
+import org.uberfire.jsbridge.tsexporter.config.AppFormerLib;
+import org.uberfire.jsbridge.tsexporter.config.Configuration;
+import org.uberfire.jsbridge.tsexporter.model.NpmPackage;
+import org.uberfire.jsbridge.tsexporter.model.NpmPackageForAppFormerLibs;
+
+import static java.util.stream.Collectors.joining;
+import static javax.tools.StandardLocation.CLASS_OUTPUT;
+import static org.uberfire.jsbridge.tsexporter.config.AppFormerLib.Type.LIB;
+
+public class TsCodegenLibBundler {
+
+    private final Configuration configuration;
+    private final TsCodegenWriter writer;
+
+    public TsCodegenLibBundler(final Configuration configuration,
+                               final TsCodegenWriter writer) {
+
+        this.configuration = configuration;
+        this.writer = writer;
+    }
+
+    public void bundle() {
+
+        configuration.getLibraries().stream()
+                .filter(lib -> lib.getType().equals(LIB))
+                .forEach(this::writeLibMainFile);
+
+        writePublicResource("AppFormerComponentsRegistry.js",
+                            new AppFormerComponentsRegistry(configuration).toSource());
+    }
+
+    private void writeLibMainFile(final AppFormerLib appformerLib) {
+        final String fileName = getAppFormerLibMainFileCopyName(appformerLib);
+
+        final NpmPackage npmPackage = new NpmPackageForAppFormerLibs(
+                appformerLib.getName(),
+                writer.getVersion(),
+                NpmPackage.Type.LIB);
+
+        final String baseDir = writer.getNpmPackageBaseDir(npmPackage, null);
+        final Path srcFilePath = writer.buildPath(baseDir, appformerLib.getMain());
+
+        try {
+            final String contents = Files.lines(srcFilePath).collect(joining("\n"));
+            writePublicResource(fileName, contents);
+        } catch (final Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void writePublicResource(final String fileName,
+                                     final String contents) {
+
+        try (final Writer filerWriter = Main.filer.createResource(CLASS_OUTPUT, "", "org/uberfire/jsbridge/public/" + fileName).openWriter()) {
+            filerWriter.write(contents);
+        } catch (final IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static String getAppFormerLibMainFileCopyName(final AppFormerLib appformerLib) {
+        return appformerLib.getName() + ".js";
+    }
+}

--- a/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/TsCodegenResult.java
+++ b/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/TsCodegenResult.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter;
+
+import java.util.Set;
+
+import org.uberfire.jsbridge.tsexporter.decorators.DecoratorStore;
+import org.uberfire.jsbridge.tsexporter.model.NpmPackageGenerated;
+import org.uberfire.jsbridge.tsexporter.model.TsExporterResource;
+import org.uberfire.jsbridge.tsexporter.model.config.LernaJson;
+import org.uberfire.jsbridge.tsexporter.model.config.PackageJsonRoot;
+
+import static org.uberfire.jsbridge.tsexporter.config.AppFormerLib.Type.LIB;
+import static org.uberfire.jsbridge.tsexporter.model.NpmPackage.Type.FINAL;
+import static org.uberfire.jsbridge.tsexporter.model.NpmPackage.Type.UNDECORATED;
+
+public class TsCodegenResult {
+
+    private final String version;
+    private final String appformerJsVersion;
+    private final DecoratorStore decoratorStore;
+    private final Set<NpmPackageGenerated> npmPackages;
+
+    public TsCodegenResult(final String version,
+                           final String appformerJsVersion,
+                           final DecoratorStore decoratorStore,
+                           final Set<NpmPackageGenerated> npmPackages) {
+
+        this.version = version;
+        this.decoratorStore = decoratorStore;
+        this.npmPackages = npmPackages;
+        this.appformerJsVersion = appformerJsVersion;
+    }
+
+    public TsExporterResource getRootPackageJson() {
+        return new PackageJsonRoot(appformerJsVersion);
+    }
+
+    public TsExporterResource getLernaJson() {
+        return new LernaJson(version, LIB);
+    }
+
+    public String getDecoratorsNpmPackageName(final NpmPackageGenerated npmPackage) {
+        return decoratorStore.getDecoratorsNpmPackageNameFor(npmPackage);
+    }
+
+    public NpmPackageGenerated getNpmPackageGeneratedByMvnModuleName(final String mvnModuleName) {
+        return npmPackages.stream()
+                .filter(s -> s.getUnscopedNpmPackageName().endsWith(mvnModuleName))
+                .filter(s -> s.getType().equals(FINAL))
+                .findFirst()
+                .get();
+    }
+
+    public Set<NpmPackageGenerated> getNpmPackages() {
+        return npmPackages;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+}

--- a/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/TsCodegenWriter.java
+++ b/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/TsCodegenWriter.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.uberfire.jsbridge.tsexporter.config.AppFormerLib;
+import org.uberfire.jsbridge.tsexporter.config.Configuration;
+import org.uberfire.jsbridge.tsexporter.model.NpmPackage;
+import org.uberfire.jsbridge.tsexporter.model.NpmPackageForAppFormerLibs;
+import org.uberfire.jsbridge.tsexporter.model.NpmPackageGenerated;
+import org.uberfire.jsbridge.tsexporter.model.TsExporterResource;
+import org.uberfire.jsbridge.tsexporter.model.config.LernaJson;
+import org.uberfire.jsbridge.tsexporter.model.config.NpmIgnore;
+import org.uberfire.jsbridge.tsexporter.model.config.PackageJsonForAggregationNpmPackage;
+
+import static java.io.File.separator;
+import static java.lang.String.format;
+import static java.lang.System.getProperty;
+import static java.nio.file.Files.createDirectories;
+import static java.nio.file.Files.createSymbolicLink;
+import static java.nio.file.Files.exists;
+import static org.uberfire.jsbridge.tsexporter.config.AppFormerLib.Type.DECORATORS;
+import static org.uberfire.jsbridge.tsexporter.config.AppFormerLib.Type.LIB;
+import static org.uberfire.jsbridge.tsexporter.model.NpmPackage.Type.FINAL;
+import static org.uberfire.jsbridge.tsexporter.util.Utils.createFileIfNotExists;
+
+public class TsCodegenWriter {
+
+    private final Configuration config;
+    private final TsCodegenResult tsCodegenResult;
+    private final String outputDir;
+
+    public TsCodegenWriter(final Configuration config,
+                           final TsCodegenResult tsCodegenResult) {
+        this.config = config;
+        this.tsCodegenResult = tsCodegenResult;
+        this.outputDir = getProperty("ts-exporter-output-dir") + "/.tsexporter";
+    }
+
+    public void write() {
+        write(tsCodegenResult.getRootPackageJson(), buildPath("", "package.json"));
+        write(tsCodegenResult.getLernaJson(), buildPath("", "lerna.json"));
+
+        tsCodegenResult.getNpmPackages().forEach(this::writeNpmPackageGenerated);
+
+        config.getLibraries().stream().filter(s -> s.getType().equals(DECORATORS))
+                .forEach(this::writeNpmPackageForDecorator);
+
+        config.getLibraries().stream().filter(s -> s.getType().equals(LIB))
+                .forEach(this::writeNpmPackageForLib);
+    }
+
+    private void writeNpmPackageForLib(final AppFormerLib lib) {
+        final NpmPackageForAppFormerLibs npmPackage = new NpmPackageForAppFormerLibs(
+                lib.getName(),
+                tsCodegenResult.getVersion(),
+                NpmPackage.Type.LIB);
+
+        final String baseDir = getNpmPackageBaseDir(npmPackage, null);
+        npmPackage.getResources().forEach(r -> this.write(r, buildPath(baseDir, r.getResourcePath())));
+    }
+
+    private void writeNpmPackageForDecorator(final AppFormerLib lib) {
+        final NpmPackageGenerated decoratedNpmPackage = tsCodegenResult.getNpmPackageGeneratedByMvnModuleName(lib.getAssociatedMvnModuleName());
+
+        final NpmPackageForAppFormerLibs decoratorsNpmPackage = new NpmPackageForAppFormerLibs(
+                lib.getName(),
+                tsCodegenResult.getVersion(),
+                NpmPackage.Type.DECORATORS);
+
+        final String baseDir = getNpmPackageBaseDir(decoratorsNpmPackage, decoratedNpmPackage);
+        decoratorsNpmPackage.getResources().forEach(r -> this.write(r, buildPath(baseDir, r.getResourcePath())));
+    }
+
+    private void writeNpmPackageGenerated(final NpmPackageGenerated npmPackage) {
+
+        final String baseDir = getNpmPackageBaseDir(npmPackage, npmPackage);
+
+        npmPackage.getClasses().forEach(
+                tsClass -> write(tsClass, buildPath(baseDir, "src/" + tsClass.getRelativePath() + ".ts")));
+
+        write(npmPackage.getIndexTs(), buildPath(baseDir, "src/index.ts"));
+        write(npmPackage.getWebpackConfigJs(), buildPath(baseDir, "webpack.config.js"));
+        write(npmPackage.getTsConfigJson(), buildPath(baseDir, "tsconfig.json"));
+        write(npmPackage.getPackageJson(), buildPath(baseDir, "package.json"));
+
+        if (npmPackage.getType().equals(FINAL)) {
+            writeAggregationNpmPackage(npmPackage, baseDir);
+        }
+    }
+
+    private void writeAggregationNpmPackage(final NpmPackageGenerated npmPackageFinal,
+                                            final String finalNpmPackageBaseDir) {
+
+        final String baseDir = finalNpmPackageBaseDir + "../../";
+        final Path distSymlinkPath = buildPath(baseDir, "dist");
+
+        try {
+            if (!exists(distSymlinkPath)) {
+                createSymbolicLink(distSymlinkPath, buildPath(finalNpmPackageBaseDir, "dist"));
+            }
+        } catch (final IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        final PackageJsonForAggregationNpmPackage packageJson = new PackageJsonForAggregationNpmPackage(
+                npmPackageFinal,
+                tsCodegenResult.getDecoratorsNpmPackageName(npmPackageFinal));
+
+        write(packageJson, buildPath(baseDir, "package.json"));
+        write(new LernaJson(npmPackageFinal.getVersion(), DECORATORS), buildPath(baseDir, "lerna.json"));
+        write(new NpmIgnore(npmPackageFinal), buildPath(baseDir, ".npmignore"));
+    }
+
+    public String getNpmPackageBaseDir(final NpmPackage npmPackage,
+                                       final NpmPackageGenerated decoratedNpmPackage) {
+
+        final String unscopedNpmPackageName = npmPackage.getUnscopedNpmPackageName();
+
+        switch (npmPackage.getType()) {
+            case RAW:
+                return format("packages/%s/packages/%s/", unscopedNpmPackageName, unscopedNpmPackageName + "-raw");
+            case FINAL:
+                return format("packages/%s/packages/%s/", unscopedNpmPackageName, unscopedNpmPackageName + "-final");
+            case DECORATORS:
+                return format("packages/%s/packages/%s/", decoratedNpmPackage.getUnscopedNpmPackageName(), unscopedNpmPackageName);
+            case UNDECORATED:
+                return format("packages/%s", unscopedNpmPackageName);
+            case LIB:
+                return format("packages/%s", unscopedNpmPackageName);
+            default:
+                throw new RuntimeException("Unknown type");
+        }
+    }
+
+    private void write(final TsExporterResource resource,
+                       final Path path) {
+
+        try {
+            System.out.println("Writing file: " + path + "...");
+            createDirectories(path.getParent());
+            Files.write(createFileIfNotExists(path), resource.toSource().getBytes());
+        } catch (final IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public Path buildPath(final String unscopedNpmPackageName,
+                          final String relativeFilePath) {
+
+        return Paths.get(format(outputDir + "/%s/%s", unscopedNpmPackageName, relativeFilePath).replace("/", separator));
+    }
+
+    public String getOutputDir() {
+        return outputDir;
+    }
+
+    public String getVersion() {
+        return tsCodegenResult.getVersion();
+    }
+}

--- a/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/config/AppFormerComponentsRegistry.java
+++ b/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/config/AppFormerComponentsRegistry.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter.config;
+
+import java.util.AbstractMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static java.lang.String.format;
+import static java.util.stream.Collectors.joining;
+import static org.uberfire.jsbridge.tsexporter.TsCodegenLibBundler.getAppFormerLibMainFileCopyName;
+import static org.uberfire.jsbridge.tsexporter.config.AppFormerLib.Type.LIB;
+import static org.uberfire.jsbridge.tsexporter.util.Utils.lines;
+
+public class AppFormerComponentsRegistry {
+
+    private final Configuration configuration;
+
+    public AppFormerComponentsRegistry(final Configuration configuration) {
+        this.configuration = configuration;
+    }
+
+    public String toSource() {
+        final String entries = configuration.getLibraries().stream()
+                .filter(lib -> lib.getType().equals(LIB))
+                .flatMap(this::bundleComponentsConfiguration)
+                .map(e -> format("\"%s\": %s", e.getKey(), e.getValue()))
+                .collect(joining(",\n"));
+
+        return format(lines("window.AppFormerComponentsRegistry = { ",
+                            "%s",
+                            "}"),
+                      entries);
+    }
+
+    private Stream<Map.Entry<String, String>> bundleComponentsConfiguration(final AppFormerLib appformerLib) {
+        return appformerLib.getComponents().stream()
+                .map(componentConfiguration -> {
+
+                    final String type = componentConfiguration.getType().name().toLowerCase();
+                    final String source = getAppFormerLibMainFileCopyName(appformerLib);
+                    final String params = componentConfiguration.getParams();
+
+                    final String configStr = format(
+                            lines("{",
+                                  "  \"type\": \"%s\",",
+                                  "  \"source\": \"%s\",",
+                                  "  \"params\": %s",
+                                  "}"),
+                            type, source, params);
+
+                    return new AbstractMap.SimpleImmutableEntry<>(componentConfiguration.getComponentId(), configStr);
+                });
+    }
+}

--- a/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/config/AppFormerLib.java
+++ b/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/config/AppFormerLib.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter.config;
+
+import java.net.URL;
+import java.util.Map;
+import java.util.Set;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import static java.util.stream.Collectors.toMap;
+import static java.util.stream.Collectors.toSet;
+import static java.util.stream.StreamSupport.stream;
+import static org.uberfire.jsbridge.tsexporter.model.TsClass.getMavenModuleNameFromSourceFilePath;
+import static org.uberfire.jsbridge.tsexporter.util.Utils.readClasspathResource;
+
+public class AppFormerLib {
+
+    private final String name;
+    private final Type type;
+    private final String associatedMvnModuleName;
+    private final Map<String, String> decorators;
+    private final String main;
+    private final Set<ComponentConfiguration> components;
+
+    public AppFormerLib(final URL url) {
+        final String jsonString = readClasspathResource(url);
+        final JsonObject json = new JsonParser().parse(jsonString).getAsJsonObject();
+
+        name = json.get("name").getAsString();
+        main = json.get("main").getAsString();
+
+        type = Type.valueOf(json.get("type").getAsString().trim().toUpperCase());
+
+        associatedMvnModuleName = getMavenModuleNameFromSourceFilePath(url.getFile());
+
+        components = stream(json.get("components").getAsJsonArray().spliterator(), false)
+                .map(ComponentConfiguration::new)
+                .collect(toSet());
+
+        decorators = json.get("decorators").getAsJsonObject()
+                .entrySet()
+                .stream()
+                .collect(toMap(Map.Entry::getKey,
+                               e -> e.getValue().getAsString()));
+    }
+
+    public String getAssociatedMvnModuleName() {
+        return associatedMvnModuleName;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Map<String, String> getDecorators() {
+        return decorators;
+    }
+
+    public Type getType() {
+        return type;
+    }
+
+    public String getMain() {
+        return main;
+    }
+
+    public Set<ComponentConfiguration> getComponents() {
+        return components;
+    }
+
+    public enum Type {
+        DECORATORS,
+        LIB
+    }
+}

--- a/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/config/ComponentConfiguration.java
+++ b/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/config/ComponentConfiguration.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter.config;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+public class ComponentConfiguration {
+
+    private final String componentId;
+    private final ComponentType type;
+    private final String params;
+
+    public ComponentConfiguration(final JsonElement json) {
+
+        final JsonObject jsonObj = json.getAsJsonObject();
+
+        this.componentId = jsonObj.get("id").getAsString();
+        this.type = ComponentType.valueOf(jsonObj.get("type").getAsString().trim().toUpperCase());
+
+        final JsonObject params = jsonObj.get("params").getAsJsonObject();
+        validateParams(params);
+        this.params = params.toString();
+    }
+
+    private void validateParams(final JsonObject params) {
+        switch (this.type) {
+            case EDITOR:
+                final JsonElement matches = params.get("matches");
+                if (matches == null || !matches.isJsonPrimitive()) {
+                    throw new RuntimeException("Property 'matches' should be a string containing a regex.");
+                }
+                break;
+            case PERSPECTIVE:
+                final JsonElement isDefault = params.get("is_default");
+                if (isDefault == null || !isDefault.isJsonPrimitive()) {
+                    throw new RuntimeException("Property 'is_default' should be a boolean.");
+                }
+                break;
+            case SCREEN:
+                break;
+        }
+    }
+
+    public String getComponentId() {
+        return this.componentId;
+    }
+
+    public ComponentType getType() {
+        return this.type;
+    }
+
+    public String getParams() {
+        return this.params;
+    }
+
+    public enum ComponentType {
+        PERSPECTIVE,
+        SCREEN,
+        EDITOR,
+    }
+}

--- a/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/config/Configuration.java
+++ b/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/config/Configuration.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter.config;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static java.lang.String.format;
+import static java.util.Collections.list;
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
+import static org.uberfire.jsbridge.tsexporter.util.Utils.getResources;
+
+public class Configuration {
+
+    private final Map<String, AppFormerLib> libsByName;
+
+    public Configuration() {
+        libsByName = list(getResources("META-INF/appformer-js.json")).stream()
+                .map(AppFormerLib::new)
+                .collect(toMap(AppFormerLib::getName, identity(), (lib1, lib2) -> {
+
+                    final String module1 = lib1.getAssociatedMvnModuleName();
+                    final String module2 = lib2.getAssociatedMvnModuleName();
+
+                    if (!module1.equals(module2)) {
+                        final String errorMsg = format("Multiple AppFormerLibs with same name %s! (Modules %s and %s)",
+                                                       lib1.getName(), module1, module2);
+                        throw new IllegalStateException(errorMsg);
+                    }
+
+                    return lib1;
+                }));
+    }
+
+    public Set<AppFormerLib> getLibraries() {
+        return new HashSet<>(libsByName.values());
+    }
+}

--- a/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/config/PerspectiveComponentParams.java
+++ b/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/config/PerspectiveComponentParams.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter.config;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import static org.uberfire.jsbridge.tsexporter.config.PerspectiveComponentParams.Fields.IS_DEFAULT;
+
+public class PerspectiveComponentParams {
+
+    public static Map<String, String> fromJson(final JsonObject json) {
+
+        final Map<String, String> params = new HashMap<>();
+
+        if (json == null) {
+            return params;
+        }
+
+        getBoolean(IS_DEFAULT, json).ifPresent(data -> params.put(IS_DEFAULT.fieldName, data.toString()));
+
+        return params;
+    }
+
+    private static Optional<Boolean> getBoolean(final Fields field, final JsonObject json) {
+        return get(field, json, JsonElement::getAsBoolean);
+    }
+
+    private static <T> Optional<T> get(final Fields field,
+                                       final JsonObject json,
+                                       final Function<JsonElement, T> extractor) {
+
+        final JsonElement element = json.get(field.fieldName);
+        if (element.isJsonNull()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(extractor.apply(element));
+    }
+
+    enum Fields {
+        IS_DEFAULT("is_default");
+
+        private final String fieldName;
+
+        Fields(final String fieldName) {
+            this.fieldName = fieldName;
+        }
+    }
+}

--- a/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/decorators/DecoratorStore.java
+++ b/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/decorators/DecoratorStore.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter.decorators;
+
+import java.util.Map;
+import java.util.Set;
+
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeMirror;
+
+import org.uberfire.jsbridge.tsexporter.config.Configuration;
+import org.uberfire.jsbridge.tsexporter.model.NpmPackageGenerated;
+import org.uberfire.jsbridge.tsexporter.model.PojoTsClass;
+import org.uberfire.jsbridge.tsexporter.util.Lazy;
+
+import static java.lang.String.format;
+import static java.util.Collections.emptySet;
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
+import static java.util.stream.Collectors.toSet;
+import static org.uberfire.jsbridge.tsexporter.Main.types;
+import static org.uberfire.jsbridge.tsexporter.config.AppFormerLib.Type.DECORATORS;
+
+public class DecoratorStore {
+
+    public static final DecoratorStore NO_DECORATORS = new DecoratorStore(emptySet());
+
+    private final Lazy<Map<String, ImportEntryForDecorator>> decorators;
+
+    public DecoratorStore(final Configuration config) {
+        this.decorators = new Lazy<>(() -> asMap(readDecoratorFiles(config)));
+    }
+
+    public DecoratorStore(final Set<ImportEntryForDecorator> decorators) {
+        this.decorators = new Lazy<>(() -> asMap(decorators));
+    }
+
+    private DecoratorStore(final Map<String, ImportEntryForDecorator> decorators) {
+        this.decorators = new Lazy<>(() -> decorators);
+    }
+
+    private Map<String, ImportEntryForDecorator> asMap(final Set<ImportEntryForDecorator> decorators) {
+        return decorators.stream()
+                .collect(toMap(ImportEntryForDecorator::getDecoratedFqcn, identity(), (kept, discarded) -> {
+                    System.out.println(format("Found more than one decorator for %s. Keeping %s and discarding %s.", kept.getDecoratedFqcn(), kept.getDecoratorPath(), discarded.getDecoratorPath()));
+                    return kept;
+                }));
+    }
+
+    private Set<ImportEntryForDecorator> readDecoratorFiles(final Configuration config) {
+        return config.getLibraries().stream()
+                .filter(lib -> lib.getType().equals(DECORATORS))
+                .flatMap(lib -> lib.getDecorators().entrySet().stream().map(e -> new ImportEntryForDecorator(
+                        lib.getAssociatedMvnModuleName(),
+                        lib.getName(),
+                        e.getKey(),
+                        e.getValue())))
+                .collect(toSet());
+    }
+
+    public boolean shouldDecorate(final TypeMirror type, final TypeMirror owner) {
+        return decorators.get().containsKey(types.erasure(type).toString());
+    }
+
+    public ImportEntryForDecorator getDecoratorFor(final TypeMirror type) {
+        return decorators.get().get(types.erasure(type).toString());
+    }
+
+    public boolean hasDecoratorsFor(final String unscopedNpmPackageName) {
+        return decorators.get().values().stream()
+                .map(ImportEntryForDecorator::getDecoratedMvnModule)
+                .collect(toSet())
+                .contains(unscopedNpmPackageName);
+    }
+
+    public DecoratorStore ignoringForCurrentNpmPackage() {
+        return new DecoratorStore(decorators.get()) {
+            @Override
+            public DecoratorStore ignoringForCurrentNpmPackage() {
+                return this;
+            }
+
+            @Override
+            public boolean shouldDecorate(final TypeMirror type, final TypeMirror owner) {
+                final String unscopedNpmPackageName = new PojoTsClass((DeclaredType) owner, this).getUnscopedNpmPackageName();
+                return super.shouldDecorate(type, owner) && !this.getDecoratorFor(type).getDecoratedMvnModule().equals(unscopedNpmPackageName);
+            }
+        };
+    }
+
+    public String getDecoratorsNpmPackageNameFor(final NpmPackageGenerated npmPackage) {
+        return decorators.get().values().stream()
+                .collect(toMap(ImportEntryForDecorator::getDecoratedMvnModule,
+                               ImportEntryForDecorator::getNpmPackageName,
+                               (a, b) -> a))
+                .get(npmPackage.getUnscopedNpmPackageName());
+    }
+}

--- a/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/decorators/ImportEntryForDecorator.java
+++ b/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/decorators/ImportEntryForDecorator.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter.decorators;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.type.DeclaredType;
+
+import org.uberfire.jsbridge.tsexporter.dependency.ImportEntry;
+
+import static org.uberfire.jsbridge.tsexporter.Main.elements;
+
+public class ImportEntryForDecorator implements ImportEntry {
+
+    private final String decoratedMvnModule;
+    private final String npmPackageName;
+    private final String decoratorPath;
+    private final String decoratedFqcn;
+
+    public ImportEntryForDecorator(final String decoratedMvnModule,
+                                   final String npmPackageName,
+                                   final String decoratorPath,
+                                   final String decoratedFqcn) {
+
+        this.decoratedMvnModule = decoratedMvnModule;
+        this.npmPackageName = npmPackageName;
+        this.decoratorPath = decoratorPath;
+        this.decoratedFqcn = decoratedFqcn;
+    }
+
+    @Override
+    public String getUniqueTsIdentifier(final DeclaredType owner) {
+        return decoratorPath.replace("/", "_").replace("-", "");
+    }
+
+    @Override
+    public String getRelativePath() {
+        return decoratorPath;
+    }
+
+    public String getNpmPackageName() {
+        return npmPackageName;
+    }
+
+    @Override
+    public Element asElement() {
+        return elements.getTypeElement(decoratedFqcn);
+    }
+
+    public String getDecoratedFqcn() {
+        return decoratedFqcn;
+    }
+
+    public String getDecoratorPath() {
+        return decoratorPath;
+    }
+
+    @Override
+    public boolean represents(final DeclaredType type) {
+        return false;
+    }
+
+    public String getDecoratedMvnModule() {
+        return decoratedMvnModule;
+    }
+}

--- a/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/decorators/ImportEntryForShadowedDecorator.java
+++ b/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/decorators/ImportEntryForShadowedDecorator.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter.decorators;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.type.DeclaredType;
+
+import org.uberfire.jsbridge.tsexporter.dependency.ImportEntry;
+
+import static org.uberfire.jsbridge.tsexporter.model.TsClass.PACKAGES_SCOPE;
+
+public class ImportEntryForShadowedDecorator implements ImportEntry {
+
+    private final ImportEntryForDecorator importEntry;
+
+    public ImportEntryForShadowedDecorator(final ImportEntryForDecorator importEntry) {
+        this.importEntry = importEntry;
+    }
+
+    @Override
+    public String getUniqueTsIdentifier(final DeclaredType owner) {
+        return importEntry.getUniqueTsIdentifier(owner);
+    }
+
+    @Override
+    public String getRelativePath() {
+        return importEntry.getRelativePath();
+    }
+
+    @Override
+    public String getNpmPackageName() {
+        return PACKAGES_SCOPE + "/" + importEntry.getDecoratedMvnModule();
+    }
+
+    @Override
+    public Element asElement() {
+        return importEntry.asElement();
+    }
+
+    @Override
+    public boolean represents(final DeclaredType type) {
+        return importEntry.represents(type);
+    }
+}

--- a/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/dependency/DependencyGraph.java
+++ b/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/dependency/DependencyGraph.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter.dependency;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+
+import org.uberfire.jsbridge.tsexporter.decorators.DecoratorStore;
+import org.uberfire.jsbridge.tsexporter.dependency.DependencyRelation.Kind;
+import org.uberfire.jsbridge.tsexporter.model.PojoTsClass;
+import org.uberfire.jsbridge.tsexporter.util.Utils;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singletonMap;
+import static java.util.stream.Collectors.toMap;
+import static java.util.stream.Collectors.toSet;
+import static java.util.stream.Stream.concat;
+import static org.uberfire.jsbridge.tsexporter.util.Utils.diff;
+
+public class DependencyGraph {
+
+    private final Map<TypeElement, Vertex> graph;
+    private final DecoratorStore decoratorStore;
+
+    public DependencyGraph(final Stream<? extends Element> elements,
+                           final DecoratorStore decoratorStore) {
+
+        this.decoratorStore = decoratorStore;
+        this.graph = new HashMap<>();
+        elements.forEach(this::add);
+    }
+
+    public Vertex add(final Element element) {
+        if (!canBePartOfTheGraph(element)) {
+            return null;
+        }
+
+        final TypeElement typeElement = (TypeElement) element;
+        final Vertex existingVertex = graph.get(typeElement);
+        if (existingVertex != null) {
+            return existingVertex;
+        }
+
+        final Vertex vertex = new Vertex(typeElement);
+        graph.put(typeElement, vertex);
+        return vertex.init();
+    }
+
+    private boolean canBePartOfTheGraph(final Element element) {
+        return element != null && (element.getKind().isClass() || element.getKind().isInterface());
+    }
+
+    public Set<Vertex> findAllDependencies(final Set<? extends Element> elements,
+                                           final Kind... kinds) {
+
+        return traverse(elements,
+                        singletonMap(v -> v.dependencies, getEffectiveKinds(kinds)),
+                        new HashSet<>());
+    }
+
+    public Set<Vertex> findAllDependents(final Set<? extends Element> elements,
+                                         final Kind... kinds) {
+
+        return traverse(elements,
+                        singletonMap(v -> v.dependents, getEffectiveKinds(kinds)),
+                        new HashSet<>());
+    }
+
+    private HashSet<Kind> getEffectiveKinds(Kind[] kinds) {
+        return new HashSet<>(asList(kinds.length == 0 ? Kind.values() : kinds));
+    }
+
+    public Set<Vertex> traverse(final Set<? extends Element> elements,
+                                final Map<DependencyFinder, Set<Kind>> traversalConfiguration) {
+
+        return traverse(elements, traversalConfiguration, new HashSet<>());
+    }
+
+    private Set<Vertex> traverse(final Set<? extends Element> elements,
+                                 final Map<DependencyFinder, Set<Kind>> traversalConfiguration,
+                                 final Set<Vertex> visited) {
+
+        final Set<Vertex> startingPoints = elements == null ? emptySet() : elements.stream()
+                .filter(this::canBePartOfTheGraph)
+                .map(e -> ((TypeElement) e))
+                .map(graph::get)
+                .filter(Objects::nonNull)
+                .collect(toSet());
+
+        final Set<Vertex> toBeVisited = diff(startingPoints, visited);
+        visited.addAll(toBeVisited);
+
+        final Stream<Vertex> traversal = toBeVisited.stream()
+                .map(vertex -> findRelevant(vertex, traversalConfiguration))
+                .flatMap(trav -> traverse(trav, traversalConfiguration, visited).stream());
+
+        return concat(startingPoints.stream(), traversal).collect(toSet());
+    }
+
+    private Set<TypeElement> findRelevant(final Vertex vertex,
+                                          final Map<DependencyFinder, Set<Kind>> map) {
+
+        return map.entrySet().stream()
+                .flatMap(c -> c.getKey().apply(vertex).entrySet().stream()
+                        .filter(relation -> relation.getValue().stream().anyMatch(c.getValue()::contains))
+                        .map(relation -> relation.getKey().asElement()))
+                .collect(toSet());
+    }
+
+    public interface DependencyFinder {
+
+        Map<Vertex, Set<Kind>> apply(Vertex a);
+    }
+
+    public class Vertex {
+
+        private final PojoTsClass pojoClass;
+        public final Map<Vertex, Set<Kind>> dependencies;
+        public final Map<Vertex, Set<Kind>> dependents;
+
+        private Vertex(final TypeElement typeElement) {
+            this.pojoClass = new PojoTsClass((DeclaredType) typeElement.asType(), decoratorStore);
+            this.dependencies = new HashMap<>();
+            this.dependents = new HashMap<>();
+        }
+
+        private Vertex init() {
+            final Map<Vertex, Set<Kind>> dependencies = pojoClass.getDependencies().stream()
+                    .collect(toMap(relation -> DependencyGraph.this.add(relation.getImportEntry().asElement()),
+                                   DependencyRelation::getKinds,
+                                   Utils::mergeSets));
+
+            dependencies.remove(null);
+
+            this.dependencies.putAll(dependencies);
+            this.dependencies.forEach((vertex, kinds) -> vertex.dependents.merge(this, kinds, Utils::mergeSets));
+            return this;
+        }
+
+        public PojoTsClass getPojoClass() {
+            return pojoClass;
+        }
+
+        public TypeElement asElement() {
+            return pojoClass.asElement();
+        }
+
+        @Override
+        public String toString() {
+            return pojoClass.getType().toString();
+        }
+    }
+
+    Vertex vertex(final Element e) {
+        if (!canBePartOfTheGraph(e)) {
+            return null;
+        }
+        return graph.get(((TypeElement) e));
+    }
+
+    public Set<Vertex> vertices() {
+        return new HashSet<>(graph.values());
+    }
+}

--- a/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/dependency/DependencyRelation.java
+++ b/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/dependency/DependencyRelation.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter.dependency;
+
+import java.util.Set;
+
+public class DependencyRelation {
+
+    private final ImportEntry importEntry;
+    private final Set<Kind> kinds;
+
+    DependencyRelation(final ImportEntry importEntry,
+                       final Set<Kind> kinds) {
+
+        this.importEntry = importEntry;
+        this.kinds = kinds;
+    }
+
+    public ImportEntry getImportEntry() {
+        return importEntry;
+    }
+
+    public Set<Kind> getKinds() {
+        return kinds;
+    }
+
+    public enum Kind {
+        FIELD,
+        HIERARCHY,
+        CODE
+    }
+}

--- a/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/dependency/ImportEntriesStore.java
+++ b/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/dependency/ImportEntriesStore.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter.dependency;
+
+import java.util.Set;
+import java.util.stream.IntStream;
+
+import org.uberfire.jsbridge.tsexporter.meta.Translatable;
+import org.uberfire.jsbridge.tsexporter.model.TsClass;
+import org.uberfire.jsbridge.tsexporter.util.IndirectHashMap;
+import org.uberfire.jsbridge.tsexporter.util.Utils;
+
+import static java.lang.String.format;
+import static java.util.Collections.singleton;
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toSet;
+
+public class ImportEntriesStore {
+
+    private final IndirectHashMap<ImportEntry, Set<DependencyRelation.Kind>> dependencies;
+    private final TsClass tsClass;
+
+    public ImportEntriesStore(final TsClass tsClass) {
+        this.tsClass = tsClass;
+        this.dependencies = new IndirectHashMap<>(ImportEntry::getRelativePath);
+    }
+
+    public Translatable with(final DependencyRelation.Kind kind,
+                             final Translatable type) {
+
+        type.getAggregatedImportEntries().forEach(e -> dependencies.merge(e, singleton(kind), Utils::mergeSets));
+        return type;
+    }
+
+    public String getImportStatements() {
+        return getImports().stream()
+                .map(DependencyRelation::getImportEntry)
+                .map(this::toTypeScriptImportSource)
+                .sorted()
+                .collect(joining("\n"));
+    }
+
+    public Set<DependencyRelation> getImports() {
+        return dependencies.entrySet().stream()
+                .filter(e -> !e.getKey().represents(tsClass.getType()))
+                .map(e -> new DependencyRelation(e.getKey(), e.getValue()))
+                .collect(toSet());
+    }
+
+    private String toTypeScriptImportSource(final ImportEntry importEntry) {
+        final String uniqueName = importEntry.getUniqueTsIdentifier(tsClass.getType());
+
+        if (!tsClass.getNpmPackageName().equals(importEntry.getNpmPackageName())) {
+            return format("import { %s as %s } from '%s';", importEntry.getSimpleName(), uniqueName, importEntry.getNpmPackageName());
+        }
+
+        final int numberOfDirectoriesToGoBackUntilTheRootDir = tsClass.getRelativePath().split("/").length - 1;
+        final String dotDotSlashPart = IntStream.range(0, numberOfDirectoriesToGoBackUntilTheRootDir).boxed()
+                .map(i -> "../")
+                .collect(joining(""));
+
+        return format("import { %s as %s } from '%s';", importEntry.getSimpleName(), uniqueName, dotDotSlashPart + importEntry.getRelativePath());
+    }
+}

--- a/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/dependency/ImportEntry.java
+++ b/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/dependency/ImportEntry.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter.dependency;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.type.DeclaredType;
+
+import static org.uberfire.jsbridge.tsexporter.util.Utils.get;
+
+public interface ImportEntry {
+
+    String getUniqueTsIdentifier(final DeclaredType owner);
+
+    String getRelativePath();
+
+    String getNpmPackageName();
+
+    default String sourcePath() {
+        return getNpmPackageName() + "/" + getRelativePath();
+    }
+
+    Element asElement();
+
+    boolean represents(final DeclaredType type);
+
+    default String getSimpleName() {
+        return get(-1, this.getRelativePath().split("/"));
+    }
+}

--- a/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/dependency/ImportEntryBuiltIn.java
+++ b/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/dependency/ImportEntryBuiltIn.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter.dependency;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.type.DeclaredType;
+
+public class ImportEntryBuiltIn implements ImportEntry {
+
+    public static final ImportEntryBuiltIn JAVA_INTEGER = new ImportEntryBuiltIn("JavaInteger", "appformer-js","java-wrappers/JavaInteger");
+    public static final ImportEntryBuiltIn JAVA_BYTE = new ImportEntryBuiltIn("JavaByte", "appformer-js","java-wrappers/JavaByte");
+    public static final ImportEntryBuiltIn JAVA_DOUBLE = new ImportEntryBuiltIn("JavaDouble", "appformer-js","java-wrappers/JavaDouble");
+    public static final ImportEntryBuiltIn JAVA_FLOAT = new ImportEntryBuiltIn("JavaFloat", "appformer-js","java-wrappers/JavaFloat");
+    public static final ImportEntryBuiltIn JAVA_LONG = new ImportEntryBuiltIn("JavaLong", "appformer-js","java-wrappers/JavaLong");
+    public static final ImportEntryBuiltIn JAVA_NUMBER = new ImportEntryBuiltIn("JavaNumber", "appformer-js","java-wrappers/JavaNumber");
+    public static final ImportEntryBuiltIn JAVA_SHORT = new ImportEntryBuiltIn("JavaShort", "appformer-js","java-wrappers/JavaShort");
+    public static final ImportEntryBuiltIn JAVA_BIG_INTEGER = new ImportEntryBuiltIn("JavaBigInteger", "appformer-js","java-wrappers/JavaBigInteger");
+    public static final ImportEntryBuiltIn JAVA_BIG_DECIMAL = new ImportEntryBuiltIn("JavaBigDecimal", "appformer-js","java-wrappers/JavaBigDecimal");
+    public static final ImportEntryBuiltIn JAVA_TREE_SET = new ImportEntryBuiltIn("JavaTreeSet", "appformer-js","java-wrappers/JavaTreeSet");
+    public static final ImportEntryBuiltIn JAVA_LINKED_LIST = new ImportEntryBuiltIn("JavaLinkedList", "appformer-js","java-wrappers/JavaLinkedList");
+    public static final ImportEntryBuiltIn JAVA_TREE_MAP = new ImportEntryBuiltIn("JavaTreeMap", "appformer-js","java-wrappers/JavaTreeMap");
+    public static final ImportEntryBuiltIn JAVA_OPTIONAL = new ImportEntryBuiltIn("JavaOptional", "appformer-js","java-wrappers/JavaOptional");
+
+    private final String uniqueTsIdentifier;
+    private final String relativePath;
+    private final String npmPackageName;
+
+    private ImportEntryBuiltIn(final String uniqueTsIdentifier,
+                               final String npmPackageName,
+                               final String relativePath) {
+
+        this.uniqueTsIdentifier = uniqueTsIdentifier;
+        this.npmPackageName = npmPackageName;
+        this.relativePath = relativePath;
+    }
+
+    @Override
+    public String getUniqueTsIdentifier(final DeclaredType owner) {
+        return getUniqueTsIdentifier();
+    }
+
+    public String getUniqueTsIdentifier() {
+        return uniqueTsIdentifier;
+    }
+
+    @Override
+    public String getRelativePath() {
+        return relativePath;
+    }
+
+    @Override
+    public String getNpmPackageName() {
+        return npmPackageName;
+    }
+
+    @Override
+    public Element asElement() {
+        return null;
+    }
+
+    @Override
+    public boolean represents(final DeclaredType type) {
+        return false;
+    }
+}

--- a/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/dependency/ImportEntryJava.java
+++ b/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/dependency/ImportEntryJava.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter.dependency;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.type.DeclaredType;
+
+import org.uberfire.jsbridge.tsexporter.decorators.DecoratorStore;
+import org.uberfire.jsbridge.tsexporter.meta.JavaType;
+import org.uberfire.jsbridge.tsexporter.model.PojoTsClass;
+
+import static org.uberfire.jsbridge.tsexporter.meta.Translatable.SourceUsage.IMPORT_STATEMENT;
+
+public class ImportEntryJava implements ImportEntry {
+
+    private final DeclaredType declaredType;
+    private final DecoratorStore decoratorStore;
+
+    public ImportEntryJava(final DeclaredType declaredType,
+                           final DecoratorStore decoratorStore) {
+
+        this.declaredType = declaredType;
+        this.decoratorStore = decoratorStore;
+    }
+
+    @Override
+    public String getUniqueTsIdentifier(final DeclaredType owner) {
+        return new JavaType(declaredType, owner).translate(decoratorStore).toTypeScript(IMPORT_STATEMENT);
+    }
+
+    @Override
+    public String getRelativePath() {
+        return new PojoTsClass(declaredType, decoratorStore).getRelativePath();
+    }
+
+    @Override
+    public String getNpmPackageName() {
+        return new PojoTsClass(declaredType, decoratorStore).getNpmPackageName();
+    }
+
+    @Override
+    public Element asElement() {
+        return declaredType.asElement();
+    }
+
+    @Override
+    public boolean represents(final DeclaredType type) {
+        return asElement().equals(type.asElement());
+    }
+
+    @Override
+    public String toString() {
+        return declaredType.toString();
+    }
+}

--- a/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/meta/JavaType.java
+++ b/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/meta/JavaType.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter.meta;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.ArrayType;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.ExecutableType;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.type.WildcardType;
+
+import org.uberfire.jsbridge.tsexporter.Main;
+import org.uberfire.jsbridge.tsexporter.decorators.DecoratorStore;
+import org.uberfire.jsbridge.tsexporter.decorators.ImportEntryForDecorator;
+import org.uberfire.jsbridge.tsexporter.dependency.ImportEntryJava;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
+import static javax.lang.model.type.TypeKind.NONE;
+import static javax.lang.model.type.TypeKind.TYPEVAR;
+import static org.uberfire.jsbridge.tsexporter.Main.types;
+import static org.uberfire.jsbridge.tsexporter.dependency.ImportEntryBuiltIn.JAVA_BIG_DECIMAL;
+import static org.uberfire.jsbridge.tsexporter.dependency.ImportEntryBuiltIn.JAVA_BIG_INTEGER;
+import static org.uberfire.jsbridge.tsexporter.dependency.ImportEntryBuiltIn.JAVA_BYTE;
+import static org.uberfire.jsbridge.tsexporter.dependency.ImportEntryBuiltIn.JAVA_DOUBLE;
+import static org.uberfire.jsbridge.tsexporter.dependency.ImportEntryBuiltIn.JAVA_FLOAT;
+import static org.uberfire.jsbridge.tsexporter.dependency.ImportEntryBuiltIn.JAVA_INTEGER;
+import static org.uberfire.jsbridge.tsexporter.dependency.ImportEntryBuiltIn.JAVA_LINKED_LIST;
+import static org.uberfire.jsbridge.tsexporter.dependency.ImportEntryBuiltIn.JAVA_LONG;
+import static org.uberfire.jsbridge.tsexporter.dependency.ImportEntryBuiltIn.JAVA_NUMBER;
+import static org.uberfire.jsbridge.tsexporter.dependency.ImportEntryBuiltIn.JAVA_OPTIONAL;
+import static org.uberfire.jsbridge.tsexporter.dependency.ImportEntryBuiltIn.JAVA_SHORT;
+import static org.uberfire.jsbridge.tsexporter.dependency.ImportEntryBuiltIn.JAVA_TREE_MAP;
+import static org.uberfire.jsbridge.tsexporter.dependency.ImportEntryBuiltIn.JAVA_TREE_SET;
+
+public class JavaType {
+
+    public static final ThreadLocal<Boolean> SIMPLE_NAMES = ThreadLocal.withInitial(() -> Boolean.FALSE);
+
+    private final TypeMirror type;
+    private final TypeMirror owner;
+
+    public JavaType(final TypeMirror type, final TypeMirror owner) {
+        if (type == null || owner == null) {
+            throw new RuntimeException("null arguments");
+        }
+        this.type = type;
+        this.owner = owner;
+    }
+
+    public TypeMirror getType() {
+        return type;
+    }
+
+    public TypeMirror getOwner() {
+        return owner;
+    }
+
+    public Element asElement() {
+        return types.asElement(type);
+    }
+
+    public Translatable translate(final DecoratorStore decoratorStore) {
+        return translate(type, decoratorStore, new HashSet<>());
+    }
+
+    public Translatable translate(final DecoratorStore decoratorStore,
+                                  final Set<Element> visitedTypeArgumentElements) {
+
+        return translate(type, decoratorStore, visitedTypeArgumentElements);
+    }
+
+    private Translatable translate(final TypeMirror type,
+                                   final DecoratorStore decoratorStore,
+                                   final Set<Element> visitedTypeArgumentElements) {
+
+        switch (type.getKind()) {
+            case INT:
+                return new TranslatableJavaNumberWithDefaultInstantiation(JAVA_INTEGER);
+            case BYTE:
+                return new TranslatableJavaNumberWithDefaultInstantiation(JAVA_BYTE);
+            case DOUBLE:
+                return new TranslatableJavaNumberWithDefaultInstantiation(JAVA_DOUBLE);
+            case FLOAT:
+                return new TranslatableJavaNumberWithDefaultInstantiation(JAVA_FLOAT);
+            case SHORT:
+                return new TranslatableJavaNumberWithDefaultInstantiation(JAVA_SHORT);
+            case LONG:
+                return new TranslatableDefault(JAVA_LONG.getUniqueTsIdentifier(), singleton(JAVA_LONG), emptyList());
+            case VOID:
+                return new TranslatableSimple("void");
+            case NULL:
+                return new TranslatableSimple("null");
+            case CHAR:
+                return new TranslatableSimple("string");
+            case BOOLEAN:
+                return new TranslatableSimple("boolean");
+            case ARRAY:
+                final TypeMirror componentType = ((ArrayType) type).getComponentType();
+                return new TranslatableArray(translate(componentType, decoratorStore, visitedTypeArgumentElements));
+            case TYPEVAR:
+                final Element element = Main.types.asElement(type);
+                if (visitedTypeArgumentElements.contains(element)) {
+                    return new TranslatableSimple(type.toString());
+                } else {
+                    visitedTypeArgumentElements.add(element);
+                }
+
+                TypeMirror potentiallyResolvedType;
+                try {
+                    potentiallyResolvedType = types.asMemberOf((DeclaredType) owner, types.asElement(type));
+                } catch (final Exception e) {
+                    potentiallyResolvedType = type;
+                }
+
+                if (!potentiallyResolvedType.getKind().equals(TYPEVAR)) {
+                    return translate(potentiallyResolvedType, decoratorStore, visitedTypeArgumentElements);
+                }
+
+                return new TranslatableTypeVar(new JavaType(type, owner), decoratorStore);
+            case DECLARED:
+                final DeclaredType declaredType = (DeclaredType) type;
+                final List<Translatable> translatableTypeArguments = extractTypeArguments(declaredType).stream()
+                        .map(s -> s.translate(decoratorStore, visitedTypeArgumentElements))
+                        .collect(toList());
+
+                switch (declaredType.asElement().toString()) {
+                    case "java.lang.Integer":
+                        return new TranslatableJavaNumberWithDefaultInstantiation(JAVA_INTEGER);
+                    case "java.lang.Byte":
+                        return new TranslatableJavaNumberWithDefaultInstantiation(JAVA_BYTE);
+                    case "java.lang.Double":
+                        return new TranslatableJavaNumberWithDefaultInstantiation(JAVA_DOUBLE);
+                    case "java.lang.Float":
+                        return new TranslatableJavaNumberWithDefaultInstantiation(JAVA_FLOAT);
+                    case "java.lang.Long":
+                        return new TranslatableDefault(JAVA_LONG.getUniqueTsIdentifier(), singleton(JAVA_LONG), emptyList());
+                    case "java.lang.Number":
+                        return new TranslatableDefault(JAVA_NUMBER.getUniqueTsIdentifier(), singleton(JAVA_NUMBER), emptyList());
+                    case "java.lang.Short":
+                        return new TranslatableJavaNumberWithDefaultInstantiation(JAVA_SHORT);
+                    case "java.math.BigInteger":
+                        return new TranslatableDefault(JAVA_BIG_INTEGER.getUniqueTsIdentifier(), singleton(JAVA_BIG_INTEGER), emptyList());
+                    case "java.math.BigDecimal":
+                        return new TranslatableDefault(JAVA_BIG_DECIMAL.getUniqueTsIdentifier(), singleton(JAVA_BIG_DECIMAL), emptyList());
+                    case "java.util.OptionalInt":
+                        return new TranslatableSimple("number"); //FIXME: !
+                    case "java.lang.Object":
+                        return new TranslatableSimple("any /* object */");
+                    case "java.util.Date":
+                        return new TranslatableSimple("any /* date */");
+                    case "java.lang.StackTraceElement":
+                        return new TranslatableSimple("any /* stack trace element */");
+                    case "java.lang.Throwable":
+                        return new TranslatableSimple("any /* throwable */");
+                    case "javax.enterprise.event.Event":
+                        return new TranslatableSimple("any /* javax event */");
+                    case "java.lang.Boolean":
+                        return new TranslatableSimple("boolean");
+                    case "java.lang.String":
+                    case "java.lang.Character":
+                        return new TranslatableSimple("string");
+                    case "java.lang.Enum":
+                        return new TranslatableSimple("any /* enum_ */");
+                    case "java.lang.Class":
+                        return new TranslatableSimple("any /* class */");
+                    case "java.util.Map.Entry":
+                        return new TranslatableSimple("any /* map entry */");
+                    case "java.util.HashMap.Node":
+                        return new TranslatableSimple("any /* map node */");
+                    case "java.util.Optional":
+                        return new TranslatableDefault("JavaOptional", singleton(JAVA_OPTIONAL), translatableTypeArguments);
+                    case "java.util.TreeMap":
+                        return new TranslatableDefault("JavaTreeMap", singleton(JAVA_TREE_MAP), translatableTypeArguments);
+                    case "java.util.HashMap":
+                    case "java.util.Map":
+                        return new TranslatableDefault("Map", emptySet(), translatableTypeArguments);
+                    case "java.util.TreeSet":
+                        return new TranslatableDefault("JavaTreeSet", singleton(JAVA_TREE_SET), translatableTypeArguments);
+                    case "java.util.Set":
+                    case "java.util.HashSet":
+                        return new TranslatableDefault("Set", emptySet(), translatableTypeArguments);
+                    case "java.util.LinkedList":
+                        return new TranslatableDefault("JavaLinkedList", singleton(JAVA_LINKED_LIST), translatableTypeArguments);
+                    case "java.util.List":
+                    case "java.util.ArrayList":
+                    case "java.util.Collection":
+                        return new TranslatableDefault("Array", emptySet(), translatableTypeArguments);
+                    default: {
+                        if (decoratorStore.shouldDecorate(type, owner)) {
+                            final ImportEntryForDecorator decorator = decoratorStore.getDecoratorFor(type);
+                            return new TranslatableDefault(decorator.getUniqueTsIdentifier(declaredType), singleton(decorator), translatableTypeArguments);
+                        }
+
+                        final String translated = (SIMPLE_NAMES.get() || types.asElement(declaredType).equals(types.asElement(owner)))
+                                ? declaredType.asElement().getSimpleName().toString()
+                                : declaredType.asElement().toString().replace(".", "_");
+
+                        return new TranslatableDefault(translated, singleton(new ImportEntryJava(declaredType, decoratorStore)), translatableTypeArguments
+                        );
+                    }
+                }
+            case WILDCARD:
+                final WildcardType wildcardType = (WildcardType) type;
+                if (wildcardType.getExtendsBound() != null) {
+                    return translate(wildcardType.getExtendsBound(), decoratorStore, visitedTypeArgumentElements);
+                }
+
+                if (wildcardType.getSuperBound() != null) {
+                    final Translatable superBound = translate(wildcardType.getSuperBound(), decoratorStore, visitedTypeArgumentElements);
+                    return new TranslatableDefault("Partial", emptySet(), singletonList(superBound));
+                }
+
+                return new TranslatableSimple("any /* wildcard */");
+            case EXECUTABLE:
+                if (((ExecutableType) type).getTypeVariables().isEmpty()) {
+                    return new TranslatableSimple("");
+                }
+
+                final List<Translatable> dependencies = ((ExecutableType) type).getTypeVariables().stream()
+                        .map(t -> translate(t, decoratorStore, visitedTypeArgumentElements))
+                        .collect(toList());
+
+                return new TranslatableDefault("", emptySet(), dependencies);
+            case PACKAGE:
+            case NONE:
+                return new TranslatableSimple("any");
+            case ERROR:
+            case OTHER:
+            case UNION:
+            case INTERSECTION:
+            default:
+                return new TranslatableSimple("any /* unknown */");
+        }
+    }
+
+    private List<JavaType> extractTypeArguments(final DeclaredType declaredType) {
+
+        final List<JavaType> typeArguments = declaredType.getTypeArguments().stream()
+                .map(typeArgument -> new JavaType(typeArgument, owner))
+                .collect(toList());
+
+        if (!typeArguments.isEmpty()) {
+            return typeArguments;
+        }
+
+        return ((TypeElement) ((DeclaredType) types.erasure(declaredType)).asElement()).getTypeParameters().stream()
+                .map(s -> new JavaType(types.getNoType(NONE), types.getNoType(NONE)))
+                .collect(toList());
+    }
+}

--- a/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/meta/Translatable.java
+++ b/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/meta/Translatable.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter.meta;
+
+import java.util.List;
+
+import org.uberfire.jsbridge.tsexporter.dependency.ImportEntry;
+
+public interface Translatable {
+
+    String toTypeScript(final SourceUsage sourceUsage);
+
+    List<ImportEntry> getAggregatedImportEntries();
+
+    default boolean canBeSubclassed() {
+        return false;
+    }
+
+    enum SourceUsage {
+        TYPE_ARGUMENT_USE,
+        TYPE_ARGUMENT_DECLARATION,
+        IMPORT_STATEMENT,
+    }
+}

--- a/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/meta/TranslatableArray.java
+++ b/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/meta/TranslatableArray.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter.meta;
+
+import java.util.List;
+
+import org.uberfire.jsbridge.tsexporter.dependency.ImportEntry;
+
+import static java.lang.String.format;
+import static org.uberfire.jsbridge.tsexporter.meta.Translatable.SourceUsage.TYPE_ARGUMENT_USE;
+
+public class TranslatableArray implements Translatable {
+
+    private final Translatable componentTranslatable;
+
+    public TranslatableArray(final Translatable componentTranslatable) {
+        this.componentTranslatable = componentTranslatable;
+    }
+
+    @Override
+    public String toTypeScript(final SourceUsage sourceUsage) {
+        switch (sourceUsage) {
+            case TYPE_ARGUMENT_USE:
+            case TYPE_ARGUMENT_DECLARATION:
+                return format("%s[]", componentTranslatable.toTypeScript(sourceUsage));
+            case IMPORT_STATEMENT:
+                return componentTranslatable.toTypeScript(sourceUsage);
+            default:
+                throw new RuntimeException();
+        }
+    }
+
+    @Override
+    public List<ImportEntry> getAggregatedImportEntries() {
+        return componentTranslatable.getAggregatedImportEntries();
+    }
+}

--- a/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/meta/TranslatableDefault.java
+++ b/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/meta/TranslatableDefault.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter.meta;
+
+import java.util.List;
+import java.util.Set;
+
+import org.uberfire.jsbridge.tsexporter.dependency.ImportEntry;
+
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Stream.concat;
+import static org.uberfire.jsbridge.tsexporter.meta.Translatable.SourceUsage.TYPE_ARGUMENT_USE;
+
+public class TranslatableDefault implements Translatable {
+
+    private final String translated;
+    private final Set<ImportEntry> importEntries;
+    private final List<Translatable> translatableTypeArguments;
+
+    public TranslatableDefault(final String translated,
+                               final Set<ImportEntry> importEntries,
+                               final List<Translatable> translatableTypeArguments) {
+
+        this.translated = translated;
+        this.translatableTypeArguments = translatableTypeArguments;
+        this.importEntries = importEntries;
+    }
+
+    @Override
+    public String toTypeScript(final SourceUsage sourceUsage) {
+        switch (sourceUsage) {
+            case IMPORT_STATEMENT:
+                return translated;
+            case TYPE_ARGUMENT_USE:
+            case TYPE_ARGUMENT_DECLARATION:
+                return translate(sourceUsage);
+            default:
+                throw new RuntimeException();
+        }
+    }
+
+    private String translate(final SourceUsage sourceUsage) {
+        return translated + (translatableTypeArguments.size() > 0
+                ? "<" + translatableTypeArguments.stream().map(s -> s.toTypeScript(sourceUsage)).collect(joining(", ")) + ">"
+                : "");
+    }
+
+    @Override
+    public List<ImportEntry> getAggregatedImportEntries() {
+        return concat(importEntries.stream(),
+                      translatableTypeArguments.stream().flatMap(t -> t.getAggregatedImportEntries().stream()))
+                .collect(toList());
+    }
+
+    @Override
+    public boolean canBeSubclassed() {
+        return !importEntries.isEmpty();
+    }
+}

--- a/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/meta/TranslatableJavaNumberWithDefaultInstantiation.java
+++ b/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/meta/TranslatableJavaNumberWithDefaultInstantiation.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter.meta;
+
+import java.util.List;
+
+import org.uberfire.jsbridge.tsexporter.dependency.ImportEntry;
+import org.uberfire.jsbridge.tsexporter.dependency.ImportEntryBuiltIn;
+
+import static java.lang.String.format;
+import static java.util.Collections.singletonList;
+
+public class TranslatableJavaNumberWithDefaultInstantiation implements Translatable {
+
+    private final ImportEntryBuiltIn importEntry;
+
+    public TranslatableJavaNumberWithDefaultInstantiation(final ImportEntryBuiltIn importEntry) {
+        this.importEntry = importEntry;
+    }
+
+    @Override
+    public String toTypeScript(final SourceUsage sourceUsage) {
+        final String translated = importEntry.getUniqueTsIdentifier();
+        switch (sourceUsage) {
+            case IMPORT_STATEMENT:
+            case TYPE_ARGUMENT_USE:
+            case TYPE_ARGUMENT_DECLARATION:
+                return translated;
+            default:
+                throw new RuntimeException();
+        }
+    }
+
+    @Override
+    public List<ImportEntry> getAggregatedImportEntries() {
+        return singletonList(importEntry);
+    }
+}

--- a/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/meta/TranslatableSimple.java
+++ b/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/meta/TranslatableSimple.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter.meta;
+
+import java.util.List;
+
+import org.uberfire.jsbridge.tsexporter.dependency.ImportEntry;
+
+import static java.util.Collections.emptyList;
+
+public class TranslatableSimple implements Translatable {
+
+    private final String translated;
+
+    public TranslatableSimple(final String translated) {
+        this.translated = translated;
+    }
+
+    @Override
+    public String toTypeScript(final SourceUsage sourceUsage) {
+        return translated;
+    }
+
+    @Override
+    public List<ImportEntry> getAggregatedImportEntries() {
+        return emptyList();
+    }
+}

--- a/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/meta/TranslatableTypeVar.java
+++ b/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/meta/TranslatableTypeVar.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter.meta;
+
+import java.util.HashSet;
+import java.util.List;
+
+import javax.lang.model.type.TypeVariable;
+
+import org.uberfire.jsbridge.tsexporter.decorators.DecoratorStore;
+import org.uberfire.jsbridge.tsexporter.dependency.ImportEntry;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singleton;
+import static javax.lang.model.type.TypeKind.NULL;
+import static javax.lang.model.type.TypeKind.TYPEVAR;
+import static org.uberfire.jsbridge.tsexporter.meta.Translatable.SourceUsage.TYPE_ARGUMENT_USE;
+
+public class TranslatableTypeVar implements Translatable {
+
+    private final String translatedUse;
+    private final String translatedDeclaration;
+    private final List<ImportEntry> upperBoundImportEntries;
+
+    public TranslatableTypeVar(final JavaType javaType,
+                               final DecoratorStore decoratorStore) {
+
+        this.translatedUse = javaType.getType().toString();
+
+        if (!javaType.getType().getKind().equals(TYPEVAR)) {
+            this.translatedDeclaration = this.translatedUse;
+            this.upperBoundImportEntries = emptyList();
+            return;
+        }
+
+        final TypeVariable typeVariable = (TypeVariable) javaType.getType();
+        if (!hasRelevantUpperBound(typeVariable)) {
+            this.translatedDeclaration = this.translatedUse;
+            this.upperBoundImportEntries = emptyList();
+            return;
+        }
+
+        final Translatable upperBound = new JavaType(typeVariable.getUpperBound(), javaType.getOwner())
+                .translate(decoratorStore, new HashSet<>(singleton(typeVariable.asElement())));
+
+        this.translatedDeclaration = typeVariable.toString() + " extends " + upperBound.toTypeScript(TYPE_ARGUMENT_USE);
+        this.upperBoundImportEntries = upperBound.getAggregatedImportEntries();
+    }
+
+    private boolean hasRelevantUpperBound(final TypeVariable typeVariable) {
+        return !typeVariable.getUpperBound().getKind().equals(NULL)
+                && !typeVariable.getUpperBound().toString().equals("java.lang.Object");
+    }
+
+    @Override
+    public String toTypeScript(final SourceUsage sourceUsage) {
+        switch (sourceUsage) {
+            case TYPE_ARGUMENT_USE:
+                return translatedUse;
+            case TYPE_ARGUMENT_DECLARATION:
+                return translatedDeclaration;
+            case IMPORT_STATEMENT:
+            default:
+                throw new RuntimeException();
+        }
+    }
+
+    @Override
+    public List<ImportEntry> getAggregatedImportEntries() {
+        return upperBoundImportEntries;
+    }
+}

--- a/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/model/ClassPathResource.java
+++ b/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/model/ClassPathResource.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter.model;
+
+import java.util.Set;
+
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+
+import org.uberfire.jsbridge.tsexporter.dependency.DependencyRelation;
+import org.uberfire.jsbridge.tsexporter.model.TsClass;
+import org.uberfire.jsbridge.tsexporter.model.TsExporterResource;
+
+import static java.util.Collections.emptySet;
+import static org.uberfire.jsbridge.tsexporter.util.Utils.readClasspathResource;
+
+public class ClassPathResource implements TsExporterResource {
+
+    private final String source;
+    private final String npmPackageName;
+    private final String resourcePath;
+
+    public ClassPathResource(final String npmPackageName,
+                             final String resourcePath) {
+
+        this.npmPackageName = npmPackageName;
+        this.resourcePath = resourcePath;
+        this.source = readClasspathResource(getClass().getClassLoader().getResource(resourcePath));
+    }
+
+    @Override
+    public String toSource() {
+        return source;
+    }
+
+    @Override
+    public String getNpmPackageName() {
+        return npmPackageName;
+    }
+
+    @Override
+    public String getUnscopedNpmPackageName() {
+        return npmPackageName;
+    }
+
+    public String getResourcePath() {
+        return resourcePath.replace(npmPackageName + "/", "");
+    }
+}

--- a/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/model/NpmPackage.java
+++ b/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/model/NpmPackage.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter.model;
+
+public interface NpmPackage {
+
+    String getName();
+
+    String getVersion();
+
+    String getUnscopedNpmPackageName();
+
+    Type getType();
+
+    enum Type {
+        RAW,
+        FINAL,
+        DECORATORS,
+        UNDECORATED,
+        LIB,
+    }
+}

--- a/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/model/NpmPackageForAppFormerLibs.java
+++ b/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/model/NpmPackageForAppFormerLibs.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter.model;
+
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import org.reflections.Reflections;
+import org.reflections.scanners.ResourcesScanner;
+
+import static java.util.stream.Collectors.toSet;
+
+public class NpmPackageForAppFormerLibs implements NpmPackage {
+
+    private final String name;
+    private final String version;
+    private final Type type;
+    private final Set<ClassPathResource> resources;
+
+    public NpmPackageForAppFormerLibs(final String name,
+                                      final String version,
+                                      final Type type) {
+
+        this.name = name;
+        this.version = version;
+        this.type = type;
+        this.resources = new Reflections(name, new ResourcesScanner()).getResources(Pattern.compile(".*")).stream()
+                .filter(resourcePath -> !resourcePath.contains("/node_modules/"))
+                .filter(resourcePath -> !resourcePath.contains("/dist/"))
+                .map(resourcePath -> new ClassPathResource(name, resourcePath))
+                .collect(toSet());
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getVersion() {
+        return version;
+    }
+
+    @Override
+    public String getUnscopedNpmPackageName() {
+        return name;
+    }
+
+    @Override
+    public Type getType() {
+        return type;
+    }
+
+    public Set<ClassPathResource> getResources() {
+        return resources;
+    }
+}

--- a/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/model/NpmPackageGenerated.java
+++ b/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/model/NpmPackageGenerated.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter.model;
+
+import java.util.Set;
+
+import org.uberfire.jsbridge.tsexporter.model.config.IndexTs;
+import org.uberfire.jsbridge.tsexporter.model.config.PackageJsonForGeneratedNpmPackages;
+import org.uberfire.jsbridge.tsexporter.model.config.TsConfigJson;
+import org.uberfire.jsbridge.tsexporter.model.config.WebpackConfigJs;
+
+public class NpmPackageGenerated implements NpmPackage {
+
+    private final String name;
+    private final Set<? extends TsClass> classes;
+    private final String version;
+    private final Type type;
+
+    public NpmPackageGenerated(final String name,
+                               final Set<? extends TsClass> classes,
+                               final String version,
+                               final Type type) {
+
+        this.name = name;
+        this.classes = classes;
+        this.version = version;
+        this.type = type;
+    }
+
+    public Set<? extends TsClass> getClasses() {
+        return classes;
+    }
+
+    public IndexTs getIndexTs() {
+        return new IndexTs(name, classes);
+    }
+
+    public WebpackConfigJs getWebpackConfigJs() {
+        return new WebpackConfigJs(name);
+    }
+
+    public TsConfigJson getTsConfigJson() {
+        return new TsConfigJson(name);
+    }
+
+    public PackageJsonForGeneratedNpmPackages getPackageJson() {
+        return new PackageJsonForGeneratedNpmPackages(this);
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getVersion() {
+        return version;
+    }
+
+    @Override
+    public String getUnscopedNpmPackageName() {
+        return getWebpackConfigJs().getUnscopedNpmPackageName();
+    }
+
+    @Override
+    public Type getType() {
+        return type;
+    }
+}

--- a/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/model/PojoTsClass.java
+++ b/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/model/PojoTsClass.java
@@ -1,0 +1,309 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter.model;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.Name;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+
+import com.sun.tools.javac.code.Symbol;
+import org.uberfire.jsbridge.tsexporter.decorators.DecoratorStore;
+import org.uberfire.jsbridge.tsexporter.dependency.DependencyRelation;
+import org.uberfire.jsbridge.tsexporter.dependency.ImportEntriesStore;
+import org.uberfire.jsbridge.tsexporter.meta.JavaType;
+import org.uberfire.jsbridge.tsexporter.meta.Translatable;
+import org.uberfire.jsbridge.tsexporter.util.Lazy;
+
+import static java.lang.String.format;
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toList;
+import static javax.lang.model.element.ElementKind.ENUM;
+import static javax.lang.model.element.ElementKind.ENUM_CONSTANT;
+import static javax.lang.model.element.ElementKind.INTERFACE;
+import static javax.lang.model.element.Modifier.ABSTRACT;
+import static org.uberfire.jsbridge.tsexporter.decorators.DecoratorStore.NO_DECORATORS;
+import static org.uberfire.jsbridge.tsexporter.dependency.DependencyRelation.Kind.FIELD;
+import static org.uberfire.jsbridge.tsexporter.dependency.DependencyRelation.Kind.HIERARCHY;
+import static org.uberfire.jsbridge.tsexporter.meta.Translatable.SourceUsage.IMPORT_STATEMENT;
+import static org.uberfire.jsbridge.tsexporter.meta.Translatable.SourceUsage.TYPE_ARGUMENT_DECLARATION;
+import static org.uberfire.jsbridge.tsexporter.meta.Translatable.SourceUsage.TYPE_ARGUMENT_USE;
+import static org.uberfire.jsbridge.tsexporter.util.ElementUtils.getAllNonStaticFields;
+import static org.uberfire.jsbridge.tsexporter.util.ElementUtils.nonStaticFieldsIn;
+import static org.uberfire.jsbridge.tsexporter.util.Utils.formatRightToLeft;
+import static org.uberfire.jsbridge.tsexporter.util.Utils.lines;
+
+public class PojoTsClass implements TsClass {
+
+    private final DeclaredType declaredType;
+    private final DecoratorStore decoratorStore;
+    private final ImportEntriesStore importEntriesStore;
+    private final Lazy<String> source;
+    private final Lazy<Translatable> translatableSelf;
+
+    @Override
+    public String toSource() {
+        return source.get();
+    }
+
+    public PojoTsClass(final DeclaredType declaredType,
+                       final DecoratorStore decoratorStore) {
+
+        this.declaredType = declaredType;
+        this.decoratorStore = decoratorStore;
+        this.importEntriesStore = new ImportEntriesStore(this);
+        this.translatableSelf = new Lazy<>(() -> importEntriesStore.with(HIERARCHY, new JavaType(declaredType, declaredType).translate(NO_DECORATORS)));
+        this.source = new Lazy<>(() -> {
+            if (asElement().getKind().equals(INTERFACE)) {
+                return toInterface();
+            } else if (asElement().getKind().equals(ENUM)) {
+                return toEnum();
+            } else {
+                return toClass();
+            }
+        });
+    }
+
+    private String toEnum() {
+        return formatRightToLeft(
+                lines("",
+                      "import { JavaEnum } from 'appformer-js';",
+                      "",
+                      "export class %s extends JavaEnum<%s> { ",
+                      "",
+                      "  %s",
+                      "",
+                      "  protected readonly _fqcn: string = %s.__fqcn();",
+                      "",
+                      "  public static __fqcn(): string {",
+                      "    return '%s';",
+                      "  }",
+                      "",
+                      "  public static values() {",
+                      "    return [%s];",
+                      "  }",
+                      "}"
+                ),
+                this::getSimpleName,
+                this::getSimpleName,
+                this::enumFieldsDeclaration,
+                this::getSimpleNameErasure,
+                this::fqcn,
+                this::enumFieldsList
+        );
+    }
+
+    private String toInterface() {
+        return formatRightToLeft(
+                lines("",
+                      "%s",
+                      "",
+                      "export interface %s %s {",
+                      "}"),
+
+                this::imports,
+                this::getSimpleName,
+                this::interfaceHierarchy);
+    }
+
+    private String toClass() {
+        return formatRightToLeft(
+                lines("",
+                      "import { Portable } from 'appformer-js';",
+                      "%s",
+                      "",
+                      "export %s class %s %s {",
+                      "",
+                      "  protected readonly _fqcn: string = %s.__fqcn();",
+                      "",
+                      "%s",
+                      "",
+                      "  constructor(self: { %s }) {",
+                      "    %s",
+                      "    Object.assign(this, self);",
+                      "  }",
+                      "",
+                      "  public static __fqcn() : string { ",
+                      "    return '%s'; ",
+                      "  } ",
+                      "",
+                      "}"),
+
+                this::imports,
+                this::abstractOrNot,
+                this::getSimpleName,
+                this::classHierarchy,
+                this::getSimpleNameErasure,
+                this::fields,
+                this::extractConstructorArgs,
+                this::superConstructorCall,
+                this::fqcn
+        );
+    }
+
+    private String getSimpleName() {
+        return translatableSelf.get().toTypeScript(TYPE_ARGUMENT_DECLARATION);
+    }
+
+    private String getSimpleNameErasure() {
+        return translatableSelf.get().toTypeScript(IMPORT_STATEMENT);
+    }
+
+    private String imports() {
+        return importEntriesStore.getImportStatements();
+    }
+
+    private String fqcn() {
+        return ((Symbol) asElement()).flatName().toString();
+    }
+
+    private String enumFieldsDeclaration() {
+        return asElement().getEnclosedElements().stream()
+                .filter(s -> s.getKind().equals(ENUM_CONSTANT))
+                .map(this::toEnumFieldSource)
+                .collect(joining("\n  "));
+    }
+
+    private String toEnumFieldSource(final Element field) {
+        final Name enumFieldName = field.getSimpleName();
+        return format("public static readonly %s:%s = new %s(\"%s\");",
+                      enumFieldName, this.getSimpleName(), this.getSimpleName(), enumFieldName);
+    }
+
+    private String enumFieldsList() {
+        return asElement().getEnclosedElements().stream()
+                .filter(s -> s.getKind().equals(ENUM_CONSTANT))
+                .map(f -> format("%s.%s", this.getSimpleName(), f.getSimpleName()))
+                .collect(joining(", "));
+    }
+
+    private String fields() {
+        return nonStaticFieldsIn(asElement().getEnclosedElements()).stream()
+                .map(this::toFieldSource)
+                .collect(joining("\n"));
+    }
+
+    private String toFieldSource(final Element fieldElement) {
+        return format("public readonly %s?: %s = undefined;",
+                      fieldElement.getSimpleName(),
+                      importEntriesStore.with(FIELD, new JavaType(fieldElement.asType(), declaredType)
+                              .translate(decoratorStore)).toTypeScript(TYPE_ARGUMENT_USE));
+    }
+
+    private Translatable superclass() {
+        return new JavaType(asElement().getSuperclass(), declaredType).translate(NO_DECORATORS);
+    }
+
+    private String superConstructorCall() {
+        return superConstructorCall(asElement());
+    }
+
+    private String superConstructorCall(final TypeElement typeElement) {
+
+        if (!superclass().canBeSubclassed() || typeElement.getSuperclass().toString().equals("java.lang.Object")) {
+            return "";
+        }
+
+        final TypeElement superElement = (TypeElement) ((DeclaredType) typeElement.getSuperclass()).asElement();
+        final String superConstructorArgs = extractConstructorArgsStartingFrom(superElement)
+                .stream()
+                .map(f -> format("%s: self.%s", f.getSimpleName(), f.getSimpleName()))
+                .collect(joining(", "));
+
+        return format("super({ %s });", superConstructorArgs);
+    }
+
+    private String classHierarchy() {
+        final String _extends = superclass().canBeSubclassed()
+                ? "extends " + importEntriesStore.with(HIERARCHY, superclass()).toTypeScript(TYPE_ARGUMENT_USE)
+                : "";
+
+        final String portablePart = format("Portable<%s>", translatableSelf.get().toTypeScript(TYPE_ARGUMENT_USE));
+        if (interfaces().isEmpty()) {
+            return _extends + " implements " + portablePart;
+        }
+
+        final String interfacesPart = interfaces().stream()
+                .map(javaType -> importEntriesStore.with(HIERARCHY, javaType.translate(NO_DECORATORS)).toTypeScript(TYPE_ARGUMENT_USE))
+                .collect(joining(", "));
+
+        return _extends + " " + format("implements %s, %s", interfacesPart, portablePart);
+    }
+
+    private String abstractOrNot() {
+        return asElement().getModifiers().contains(ABSTRACT) ? "abstract" : "";
+    }
+
+    private String interfaceHierarchy() {
+        if (interfaces().isEmpty()) {
+            return "";
+        }
+
+        return "extends " + interfaces().stream()
+                .map(javaType -> importEntriesStore.with(HIERARCHY, javaType.translate(NO_DECORATORS)).toTypeScript(TYPE_ARGUMENT_USE))
+                .collect(joining(", "));
+    }
+
+    private List<JavaType> interfaces() {
+        return ((TypeElement) declaredType.asElement()).getInterfaces().stream()
+                .map(t -> new JavaType(t, declaredType))
+                .filter(s -> s.translate(NO_DECORATORS).canBeSubclassed())
+                .collect(toList());
+    }
+
+    private String extractConstructorArgs() {
+        return extractConstructorArgsStartingFrom(asElement())
+                .stream()
+                .map(this::formatConstructorArg)
+                .collect(joining(", "));
+    }
+
+    private String formatConstructorArg(final Element element) {
+        final Translatable translatableType = new JavaType(element.asType(), declaredType).translate(decoratorStore);
+        final String formattedType = importEntriesStore.with(FIELD, translatableType).toTypeScript(TYPE_ARGUMENT_USE);
+
+        return format("%s?: %s", element.getSimpleName(), formattedType);
+    }
+
+    private List<Element> extractConstructorArgsStartingFrom(final TypeElement typeElement) {
+
+        final List<Element> allElements = getAllNonStaticFields(typeElement);
+
+        final Set<Element> elementsUnion = new HashSet<>();
+        if (!allElements.stream().allMatch(elementsUnion::add)) {
+            throw new RuntimeException(format("Class %s has a field with the same name as one of its parent classes",
+                                              getSimpleName()));
+        }
+
+        return allElements;
+    }
+
+    @Override
+    public Set<DependencyRelation> getDependencies() {
+        source.get();
+        return importEntriesStore.getImports();
+    }
+
+    @Override
+    public DeclaredType getType() {
+        return declaredType;
+    }
+}

--- a/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/model/RpcCallerTsClass.java
+++ b/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/model/RpcCallerTsClass.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter.model;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+
+import org.uberfire.jsbridge.tsexporter.decorators.DecoratorStore;
+import org.uberfire.jsbridge.tsexporter.dependency.DependencyGraph;
+import org.uberfire.jsbridge.tsexporter.dependency.DependencyRelation;
+import org.uberfire.jsbridge.tsexporter.dependency.ImportEntriesStore;
+import org.uberfire.jsbridge.tsexporter.meta.JavaType;
+import org.uberfire.jsbridge.tsexporter.util.Lazy;
+
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toList;
+import static javax.lang.model.element.ElementKind.METHOD;
+import static org.uberfire.jsbridge.tsexporter.Main.elements;
+import static org.uberfire.jsbridge.tsexporter.decorators.DecoratorStore.NO_DECORATORS;
+import static org.uberfire.jsbridge.tsexporter.dependency.DependencyRelation.Kind.HIERARCHY;
+import static org.uberfire.jsbridge.tsexporter.meta.Translatable.SourceUsage.TYPE_ARGUMENT_DECLARATION;
+import static org.uberfire.jsbridge.tsexporter.util.Utils.formatRightToLeft;
+import static org.uberfire.jsbridge.tsexporter.util.Utils.lines;
+
+public class RpcCallerTsClass implements TsClass {
+
+    private final TypeElement typeElement;
+    private final Lazy<String> source;
+    final DependencyGraph dependencyGraph;
+    final DecoratorStore decoratorStore;
+    final ImportEntriesStore importEntriesStore;
+
+    private static final List<String> RESERVED_WORDS = Arrays.asList("delete", "copy"); //TODO: Add all
+
+    public RpcCallerTsClass(final TypeElement typeElement,
+                            final DependencyGraph dependencyGraph,
+                            final DecoratorStore decoratorStore) {
+
+        this.typeElement = typeElement;
+        this.dependencyGraph = dependencyGraph;
+        this.decoratorStore = decoratorStore;
+        this.importEntriesStore = new ImportEntriesStore(this);
+        this.source = new Lazy<>(() -> formatRightToLeft(
+                lines("",
+                      "import { rpc, marshall, unmarshall } from 'appformer-js';",
+                      "%s",
+                      "",
+                      "export class %s {",
+                      "%s",
+                      "}"),
+
+                this::imports,
+                this::simpleName,
+                this::methods
+        ));
+    }
+
+    @Override
+    public String toSource() {
+        return source.get();
+    }
+
+    private String simpleName() {
+        return importEntriesStore.with(HIERARCHY, new JavaType(getType(), getType()).translate(NO_DECORATORS)).toTypeScript(TYPE_ARGUMENT_DECLARATION);
+    }
+
+    private String methods() {
+        return elements.getAllMembers(typeElement).stream()
+                .filter(member -> member.getKind().equals(METHOD))
+                .filter(member -> !member.getEnclosingElement().toString().equals("java.lang.Object"))
+                .map(member -> new RpcCallerTsMethod((ExecutableElement) member, this))
+                .collect(groupingBy(RpcCallerTsMethod::getName)).entrySet().stream()
+                .flatMap(e -> resolveOverloadsAndReservedWords(e.getKey(), e.getValue()).stream())
+                .map(RpcCallerTsMethod::toSource)
+                .collect(joining("\n"));
+    }
+
+    private String imports() {
+        return importEntriesStore.getImportStatements();
+    }
+
+    private List<RpcCallerTsMethod> resolveOverloadsAndReservedWords(final String name,
+                                                                     final List<RpcCallerTsMethod> methodsWithTheSameName) {
+
+        if (methodsWithTheSameName.size() <= 1 && !RESERVED_WORDS.contains(name)) {
+            return methodsWithTheSameName;
+        }
+
+        final AtomicInteger i = new AtomicInteger(0);
+        return methodsWithTheSameName.stream()
+                .map(tsMethod -> new RpcCallerTsMethod(tsMethod, tsMethod.getName() + i.getAndIncrement()))
+                .collect(toList());
+    }
+
+    @Override
+    public Set<DependencyRelation> getDependencies() {
+        source.get();
+        return importEntriesStore.getImports();
+    }
+
+    @Override
+    public String getNpmPackageName() {
+        return TsClass.super.getNpmPackageName() + "-rpc";
+    }
+
+    @Override
+    public DeclaredType getType() {
+        return (DeclaredType) typeElement.asType();
+    }
+}

--- a/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/model/RpcCallerTsMethod.java
+++ b/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/model/RpcCallerTsMethod.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter.model;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Name;
+import javax.lang.model.element.TypeElement;
+
+import com.sun.tools.javac.code.Symbol;
+import org.uberfire.jsbridge.tsexporter.decorators.DecoratorStore;
+import org.uberfire.jsbridge.tsexporter.dependency.DependencyGraph;
+import org.uberfire.jsbridge.tsexporter.dependency.DependencyGraph.DependencyFinder;
+import org.uberfire.jsbridge.tsexporter.dependency.DependencyRelation;
+import org.uberfire.jsbridge.tsexporter.dependency.ImportEntriesStore;
+import org.uberfire.jsbridge.tsexporter.dependency.ImportEntry;
+import org.uberfire.jsbridge.tsexporter.meta.JavaType;
+import org.uberfire.jsbridge.tsexporter.meta.Translatable;
+import org.uberfire.jsbridge.tsexporter.meta.TranslatableJavaNumberWithDefaultInstantiation;
+
+import static java.lang.String.format;
+import static java.util.Collections.singleton;
+import static java.util.Comparator.comparing;
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toMap;
+import static java.util.stream.Collectors.toSet;
+import static javax.lang.model.element.ElementKind.CLASS;
+import static javax.lang.model.element.ElementKind.ENUM;
+import static javax.lang.model.element.ElementKind.ENUM_CONSTANT;
+import static javax.lang.model.element.Modifier.ABSTRACT;
+import static org.uberfire.jsbridge.tsexporter.Main.types;
+import static org.uberfire.jsbridge.tsexporter.decorators.DecoratorStore.NO_DECORATORS;
+import static org.uberfire.jsbridge.tsexporter.dependency.DependencyRelation.Kind.CODE;
+import static org.uberfire.jsbridge.tsexporter.dependency.DependencyRelation.Kind.FIELD;
+import static org.uberfire.jsbridge.tsexporter.dependency.DependencyRelation.Kind.HIERARCHY;
+import static org.uberfire.jsbridge.tsexporter.meta.Translatable.SourceUsage.TYPE_ARGUMENT_DECLARATION;
+import static org.uberfire.jsbridge.tsexporter.meta.Translatable.SourceUsage.TYPE_ARGUMENT_USE;
+import static org.uberfire.jsbridge.tsexporter.util.ElementUtils.getAllNonStaticFields;
+import static org.uberfire.jsbridge.tsexporter.util.Utils.lines;
+
+public class RpcCallerTsMethod {
+
+    private final ExecutableElement executableElement;
+    private final TypeElement owner;
+    private final ImportEntriesStore importStore;
+    private final String name;
+    private final DependencyGraph dependencyGraph;
+    private final DecoratorStore decoratorStore;
+
+    RpcCallerTsMethod(final RpcCallerTsMethod tsMethod,
+                      final String name) {
+
+        this.owner = tsMethod.owner;
+        this.executableElement = tsMethod.executableElement;
+        this.importStore = tsMethod.importStore;
+        this.dependencyGraph = tsMethod.dependencyGraph;
+        this.decoratorStore = tsMethod.decoratorStore;
+        this.name = name;
+    }
+
+    RpcCallerTsMethod(final ExecutableElement executableElement,
+                      final RpcCallerTsClass rpcCallerTsClass) {
+
+        this.executableElement = executableElement;
+        this.name = executableElement.getSimpleName().toString();
+        this.owner = rpcCallerTsClass.asElement();
+        this.importStore = rpcCallerTsClass.importEntriesStore;
+        this.dependencyGraph = rpcCallerTsClass.dependencyGraph;
+        this.decoratorStore = rpcCallerTsClass.decoratorStore;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String toSource() {
+        final String name = methodDeclaration();
+        final String params = params();
+        final String erraiBusString = erraiBusString();
+        final String rpcCallParams = rpcCallParams();
+        final String returnType = returnType();
+
+        final String factoriesOracle = factoriesOracle(); //Has to be the last
+
+        return format(lines("",
+                            "public %s(args: { %s }) {",
+                            "  return rpc(%s, [%s])",
+                            "         .then((json: string) => {",
+                            "           return unmarshall(json, new Map([",
+                            "%s",
+                            "           ])) as %s;",
+                            "         });",
+                            "}",
+                            ""),
+
+                      name,
+                      params,
+                      erraiBusString,
+                      rpcCallParams,
+                      factoriesOracle,
+                      returnType);
+    }
+
+    private String returnType() {
+        return importing(translatedReturnType()).toTypeScript(TYPE_ARGUMENT_USE);
+    }
+
+    private String methodDeclaration() {
+        final JavaType methodType = new JavaType(executableElement.asType(), owner.asType());
+        return name + importing(methodType.translate(NO_DECORATORS)).toTypeScript(TYPE_ARGUMENT_DECLARATION);
+    }
+
+    private String params() {
+        return getParameterJavaTypesByNames().entrySet().stream()
+                .map(e -> format("%s: %s", e.getKey(), importing(e.getValue().translate(NO_DECORATORS)).toTypeScript(TYPE_ARGUMENT_USE)))
+                .collect(joining(", "));
+    }
+
+    private String erraiBusString() {
+        return '"' +
+                owner.getQualifiedName().toString() +
+                "|" +
+                executableElement.getSimpleName() +
+                ":" +
+                executableElement.getParameters().stream()
+                        .map(Element::asType)
+                        .map(type -> Optional.ofNullable(types.erasure(type)))
+                        .filter(Optional::isPresent).map(Optional::get)
+                        .map(element -> element.toString() + ":") //FIXME: This is probably not 100% right
+                        .collect(joining("")) +
+                '"';
+    }
+
+    private String rpcCallParams() {
+        return getParameterJavaTypesByNames().entrySet().stream()
+                .map(param -> format("marshall(%s)", "args." + param.getKey()))
+                .collect(joining(", "));
+    }
+
+    private String factoriesOracle() {
+
+        final Set<? extends Element> aggregatedTypesOfReturnType = translatedReturnType().getAggregatedImportEntries().stream()
+                .map(ImportEntry::asElement)
+                .collect(toSet());
+
+        final Map<DependencyFinder, Set<DependencyRelation.Kind>> traversalConfiguration = new HashMap<>();
+        traversalConfiguration.put(vertex -> vertex.dependencies, singleton(FIELD));
+        traversalConfiguration.put(vertex -> vertex.dependents, singleton(HIERARCHY));
+
+        return new HashSet<>(dependencyGraph.traverse(aggregatedTypesOfReturnType, traversalConfiguration)).stream()
+                .map(DependencyGraph.Vertex::getPojoClass)
+                .sorted(comparing(TsClass::getRelativePath))
+                .filter(this::isInstantiable)
+                .distinct()
+                .map(this::toFactoriesOracleEntry)
+                .collect(joining(",\n"));
+    }
+
+    private String toFactoriesOracleEntry(final PojoTsClass tsClass) {
+        final JavaType javaType = new JavaType(types.erasure(tsClass.getType()), owner.asType());
+        return format("[\"%s\", %s]",
+                      ((Symbol) tsClass.asElement()).flatName().toString(),
+                      getOracleFactoryMethodEntry(javaType));
+    }
+
+    private String getOracleFactoryMethodEntry(final JavaType javaType) {
+
+        final TypeElement javaTypeElement = (TypeElement) javaType.asElement();
+
+        if (javaTypeElement.getKind() == ENUM) {
+            return this.toEnumFactoryMethodSource(javaType);
+        }
+
+        final String defaultNumbersInitialization = getAllNonStaticFields(javaTypeElement).stream()
+                .flatMap(field -> toOracleFactoryMethodConstructorEntry(field, new JavaType(field.asType(), javaType.getType())))
+                .collect(joining(", "));
+
+        return format("() => new %s({ %s }) as any",
+                      importing(javaType.translate(decoratorStore)).toTypeScript(TYPE_ARGUMENT_USE),
+                      defaultNumbersInitialization);
+    }
+
+    private String toEnumFactoryMethodSource(final JavaType javaType) {
+
+        final TypeElement typeElement = (TypeElement) javaType.asElement();
+        final String enumName = importing(javaType.translate(decoratorStore)).toTypeScript(TYPE_ARGUMENT_USE);
+        final String caseClauses = typeElement.getEnclosedElements().stream()
+                .filter(s -> s.getKind().equals(ENUM_CONSTANT))
+                .map(f -> toEnumConstantFactorySource(enumName, f.getSimpleName()))
+                .collect(joining(" "));
+
+        final String defaultClause = format("default: throw new Error(`Unknown value ${name} for enum %s!`);", enumName);
+        return format("((name: string) => { switch (name) { %s %s }}) as any", caseClauses, defaultClause);
+    }
+
+    private String toEnumConstantFactorySource(final String enumName, final Name enumConstantName) {
+        return format("case \"%s\": return %s.%s;", enumConstantName, enumName, enumConstantName);
+    }
+
+    private Stream<String> toOracleFactoryMethodConstructorEntry(final Element fieldElement,
+                                                                 final JavaType fieldJavaType) {
+
+        final Translatable translatedFieldType = fieldJavaType.translate(decoratorStore);
+        if (!(translatedFieldType instanceof TranslatableJavaNumberWithDefaultInstantiation)) {
+            return Stream.empty();
+        }
+
+        final String fieldType = importStore.with(CODE, translatedFieldType).toTypeScript(TYPE_ARGUMENT_USE);
+        return Stream.of(format("%s: new %s(\"0\")", fieldElement.getSimpleName(), fieldType));
+    }
+
+    private boolean isInstantiable(final PojoTsClass tsClass) {
+        final Element element = tsClass.asElement();
+        return isConcreteClass(element) || isEnumClass(element);
+    }
+
+    private boolean isConcreteClass(final Element element) {
+        return element.getKind().equals(CLASS) && !element.getModifiers().contains(ABSTRACT);
+    }
+
+    private boolean isEnumClass(final Element element) {
+        return element.getKind().equals(ENUM);
+    }
+
+    private Translatable translatedReturnType() {
+        return new JavaType(executableElement.getReturnType(), owner.asType()).translate(decoratorStore);
+    }
+
+    private Translatable importing(final Translatable translatable) {
+        translatable.getAggregatedImportEntries().stream()
+                .map(ImportEntry::asElement)
+                .forEach(dependencyGraph::add);
+
+        return importStore.with(CODE, translatable);
+    }
+
+    private LinkedHashMap<String, JavaType> getParameterJavaTypesByNames() {
+        return this.executableElement.getParameters().stream().collect(
+                toMap(arg -> arg.getSimpleName().toString(),
+                      arg -> new JavaType(arg.asType(), owner.asType()),
+                      (a, b) -> b, //default map behavior
+                      LinkedHashMap::new)); //order is important!
+    }
+}

--- a/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/model/TsClass.java
+++ b/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/model/TsClass.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter.model;
+
+import java.lang.reflect.Field;
+import java.util.Set;
+
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+
+import com.sun.tools.javac.code.Symbol;
+import org.uberfire.jsbridge.tsexporter.dependency.DependencyRelation;
+
+import static org.uberfire.jsbridge.tsexporter.util.Utils.get;
+
+public interface TsClass extends TsExporterResource {
+
+    public static final String PACKAGES_SCOPE = "@kiegroup-ts-generated";
+
+    Set<DependencyRelation> getDependencies();
+
+    DeclaredType getType();
+
+    default TypeElement asElement() {
+        return ((TypeElement) getType().asElement());
+    }
+
+    default String getRelativePath() {
+        return asElement().getQualifiedName().toString().replace(".", "/");
+    }
+
+    @Override
+    default String getNpmPackageName() {
+
+        if (getType().toString().matches("^javax?.*")) {
+            return PACKAGES_SCOPE + "/" + "java";
+        }
+
+        try {
+            final Class<?> clazz = Class.forName(((Symbol) asElement()).flatName().toString());
+            return PACKAGES_SCOPE + "/" + getMavenModuleNameFromSourceFilePath(clazz.getResource('/' + clazz.getName().replace('.', '/') + ".class").toString());
+        } catch (final ClassNotFoundException e) {
+            try {
+                final Field sourceFileField = asElement().getClass().getField("sourcefile");
+                sourceFileField.setAccessible(true);
+                return PACKAGES_SCOPE + "/" + getMavenModuleNameFromSourceFilePath(sourceFileField.get(asElement()).toString());
+            } catch (final Exception e1) {
+                throw new RuntimeException("Error while reading [sourcefile] field from @Remote interface element.", e1);
+            }
+        }
+    }
+
+    public static String getMavenModuleNameFromSourceFilePath(final String sourceFilePath) {
+
+        if (sourceFilePath.contains("jar!")) {
+            return get(-2, sourceFilePath.split("(/)[\\w-]+(-)[\\d.]+(.*)\\.jar!")[0].split("/"));
+        }
+
+        if (sourceFilePath.contains("/src/main/java")) {
+            return get(-1, sourceFilePath.split("/src/main/java")[0].split("/"));
+        }
+
+        if (sourceFilePath.contains("/target/generated-sources")) {
+            return get(-1, sourceFilePath.split("/target/generated-sources")[0].split("/"));
+        }
+
+        if (sourceFilePath.contains("/target/classes")) {
+            return get(-1, sourceFilePath.split("/target/classes")[0].split("/"));
+        }
+
+        if (sourceFilePath.contains("/src/test/java")) {
+            return get(-1, sourceFilePath.split("/src/test/java")[0].split("/")) + "-test";
+        }
+
+        if (sourceFilePath.contains("/target/generated-test-sources")) {
+            return get(-1, sourceFilePath.split("/target/generated-test-sources")[0].split("/")) + "-test";
+        }
+
+        if (sourceFilePath.contains("/target/test-classes")) {
+            return get(-1, sourceFilePath.split("/target/test-classes")[0].split("/")) + "-test";
+        }
+
+        throw new RuntimeException("Maven module name unretrievable from [" + sourceFilePath + "]");
+    }
+}

--- a/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/model/TsExporterResource.java
+++ b/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/model/TsExporterResource.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter.model;
+
+import static org.uberfire.jsbridge.tsexporter.util.Utils.get;
+
+public interface TsExporterResource {
+
+    String toSource();
+
+    String getNpmPackageName();
+
+    default String getUnscopedNpmPackageName() {
+        return get(-1, getNpmPackageName().split("/"));
+    }
+}

--- a/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/model/config/IndexTs.java
+++ b/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/model/config/IndexTs.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter.model.config;
+
+import java.util.List;
+import java.util.Set;
+
+import org.uberfire.jsbridge.tsexporter.model.TsClass;
+import org.uberfire.jsbridge.tsexporter.model.TsExporterResource;
+
+import static java.lang.String.format;
+import static java.util.stream.Collectors.joining;
+
+public class IndexTs implements TsExporterResource {
+
+    private final String npmPackageName;
+    private final Set<? extends TsClass> classes;
+
+    public IndexTs(final String npmPackageName,
+                   final Set<? extends TsClass> classes) {
+
+        this.npmPackageName = npmPackageName;
+        this.classes = classes;
+    }
+
+    @Override
+    public String toSource() {
+        return classes.stream()
+                .map(s -> format("export * from './%s';", s.getRelativePath()))
+                .collect(joining("\n"));
+    }
+
+    @Override
+    public String getNpmPackageName() {
+        return npmPackageName;
+    }
+}

--- a/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/model/config/LernaJson.java
+++ b/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/model/config/LernaJson.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter.model.config;
+
+import org.uberfire.jsbridge.tsexporter.config.AppFormerLib;
+import org.uberfire.jsbridge.tsexporter.model.TsExporterResource;
+
+import static java.lang.String.format;
+import static org.uberfire.jsbridge.tsexporter.util.Utils.lines;
+
+public class LernaJson implements TsExporterResource {
+
+    private final String version;
+    private final AppFormerLib.Type type;
+
+    public LernaJson(final String version,
+                     final AppFormerLib.Type type) {
+
+        this.version = version;
+        this.type = type;
+    }
+
+    @Override
+    public String toSource() {
+        return format(lines(
+                "{",
+                "  \"lerna\": \"3.4.0\",",
+                "  \"npmClient\": \"yarn\",",
+                "  \"useWorkspaces\": %s,",
+                "  \"version\": \"%s\",",
+                "  \"npmClientArgs\": [",
+                "    \"--no-lockfile\", \"--registry http://localhost:4873\"",
+                "  ]",
+                "}"),
+
+                      type.equals(AppFormerLib.Type.DECORATORS) ? "false" : "true",
+                      version);
+    }
+
+    @Override
+    public String getNpmPackageName() {
+        return "";
+    }
+}

--- a/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/model/config/NpmIgnore.java
+++ b/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/model/config/NpmIgnore.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter.model.config;
+
+import org.uberfire.jsbridge.tsexporter.model.NpmPackageGenerated;
+import org.uberfire.jsbridge.tsexporter.model.TsExporterResource;
+
+import static org.uberfire.jsbridge.tsexporter.util.Utils.lines;
+
+public class NpmIgnore implements TsExporterResource {
+
+    private final NpmPackageGenerated npmPackage;
+
+    public NpmIgnore(final NpmPackageGenerated npmPackage) {
+        this.npmPackage = npmPackage;
+    }
+
+    @Override
+    public String toSource() {
+        return lines(
+                "**/packages",
+                "**/lerna.json"
+        );
+    }
+
+    @Override
+    public String getNpmPackageName() {
+        return npmPackage.getName();
+    }
+}

--- a/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/model/config/PackageJsonForAggregationNpmPackage.java
+++ b/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/model/config/PackageJsonForAggregationNpmPackage.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter.model.config;
+
+import org.uberfire.jsbridge.tsexporter.decorators.ImportEntryForDecorator;
+import org.uberfire.jsbridge.tsexporter.decorators.ImportEntryForShadowedDecorator;
+import org.uberfire.jsbridge.tsexporter.dependency.DependencyRelation;
+import org.uberfire.jsbridge.tsexporter.dependency.ImportEntry;
+import org.uberfire.jsbridge.tsexporter.model.NpmPackageGenerated;
+import org.uberfire.jsbridge.tsexporter.model.TsExporterResource;
+
+import static java.lang.String.format;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.joining;
+import static org.uberfire.jsbridge.tsexporter.util.Utils.lines;
+
+public class PackageJsonForAggregationNpmPackage implements TsExporterResource {
+
+    private final NpmPackageGenerated npmPackage;
+    private final String decoratorsNpmPackageName;
+
+    public PackageJsonForAggregationNpmPackage(final NpmPackageGenerated npmPackage,
+                                               final String decoratorsNpmPackageName) {
+
+        this.npmPackage = npmPackage;
+        this.decoratorsNpmPackageName = decoratorsNpmPackageName;
+    }
+
+    @Override
+    public String toSource() {
+        final String dependenciesPart = npmPackage.getClasses().stream()
+                .flatMap(clazz -> clazz.getDependencies().stream())
+                .map(DependencyRelation::getImportEntry)
+                .map(importEntry -> importEntry instanceof ImportEntryForDecorator
+                        ? new ImportEntryForShadowedDecorator((ImportEntryForDecorator) importEntry)
+                        : importEntry)
+                .collect(groupingBy(ImportEntry::getNpmPackageName))
+                .keySet().stream()
+                .filter(name -> !name.equals(npmPackage.getName()))
+                .filter(name -> !name.contains("appformer-js"))
+                .sorted()
+                .map(name -> format("\"%s\": \"%s\"", name, npmPackage.getVersion()))
+                .collect(joining(",\n"));
+
+        return format(lines(
+                "{",
+                "  \"name\": \"%s\",",
+                "  \"version\": \"%s\",",
+                "  \"license\": \"Apache-2.0\",",
+                "  \"main\": \"./dist/index.js\",",
+                "  \"types\": \"./dist/index.d.ts\",",
+                "  \"dependencies\": {",
+                "%s",
+                "  },",
+                "  \"scripts\": {",
+                "    \"build:ts-exporter\": \"" +
+                        "ln -s ../../node_modules node_modules && " +
+                        "npx lerna bootstrap --registry http://localhost:4873 && " +
+                        "npx lerna exec -- yarn run build:ts-exporter && " +
+                        "yarn add %s --no-lockfile --registry http://localhost:4873 && " +
+                        "mv dist dist.tmp && " +
+                        "mv `readlink dist.tmp` . && " +
+                        "rm dist.tmp && " +
+                        "(%s || (" +
+                        "npm unpublish -f --registry http://localhost:4873 && " +
+                        "yarn publish --new-version %s --registry http://localhost:4873" +
+                        "))" +
+                        "\"",
+                "  },",
+                "  \"devDependencies\": {",
+                "    \"lerna\": \"^3.4.0\"",
+                "  }",
+                "}"),
+
+                      npmPackage.getName(),
+                      npmPackage.getVersion(),
+                      dependenciesPart,
+                      decoratorsNpmPackageName,
+                      Boolean.getBoolean("ts-exporter.publish.skip"),
+                      npmPackage.getVersion()
+
+        );
+    }
+
+    @Override
+    public String getNpmPackageName() {
+        return npmPackage.getName();
+    }
+}

--- a/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/model/config/PackageJsonForGeneratedNpmPackages.java
+++ b/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/model/config/PackageJsonForGeneratedNpmPackages.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter.model.config;
+
+import org.uberfire.jsbridge.tsexporter.decorators.ImportEntryForDecorator;
+import org.uberfire.jsbridge.tsexporter.decorators.ImportEntryForShadowedDecorator;
+import org.uberfire.jsbridge.tsexporter.dependency.DependencyRelation;
+import org.uberfire.jsbridge.tsexporter.dependency.ImportEntry;
+import org.uberfire.jsbridge.tsexporter.model.NpmPackageGenerated;
+import org.uberfire.jsbridge.tsexporter.model.TsExporterResource;
+
+import static java.lang.String.format;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.joining;
+import static org.uberfire.jsbridge.tsexporter.model.NpmPackage.Type.FINAL;
+import static org.uberfire.jsbridge.tsexporter.model.NpmPackage.Type.RAW;
+import static org.uberfire.jsbridge.tsexporter.util.Utils.lines;
+
+public class PackageJsonForGeneratedNpmPackages implements TsExporterResource {
+
+    private final NpmPackageGenerated npmPackage;
+
+    public PackageJsonForGeneratedNpmPackages(final NpmPackageGenerated npmPackage) {
+        this.npmPackage = npmPackage;
+    }
+
+    @Override
+    public String toSource() {
+        final String dependenciesPart = npmPackage.getClasses().stream()
+                .flatMap(clazz -> clazz.getDependencies().stream())
+                .map(DependencyRelation::getImportEntry)
+                .map(importEntry -> npmPackage.getType().equals(FINAL) || !(importEntry instanceof ImportEntryForDecorator)
+                        ? importEntry
+                        : new ImportEntryForShadowedDecorator((ImportEntryForDecorator) importEntry))
+                .collect(groupingBy(ImportEntry::getNpmPackageName))
+                .keySet().stream()
+                .filter(name -> !name.equals(npmPackage.getName()))
+                .filter(name -> !name.contains("appformer-js"))
+                .sorted()
+                .map(name -> format("\"%s\": \"%s\"", name, npmPackage.getVersion()))
+                .collect(joining(",\n"));
+
+        final String version = npmPackage.getVersion() + (npmPackage.getType().equals(RAW) ? "-raw" : "");
+
+        final String publishCommand = npmPackage.getType().equals(FINAL)
+                ? "echo 'Skipping publish'"
+                : format("yarn publish --new-version %s --registry http://localhost:4873", version);
+
+        return format(lines("{",
+                            "  \"name\": \"%s\",",
+                            "  \"version\": \"%s\",",
+                            "  \"license\": \"Apache-2.0\",",
+                            "  \"main\": \"./dist/index.js\",",
+                            "  \"types\": \"./dist/index.d.ts\",",
+                            "  \"dependencies\": {",
+                            "%s",
+                            "  },",
+                            "  \"scripts\": {",
+                            "    \"build:ts-exporter\": \"" +
+                                    "npx webpack && " +
+                                    "(%s || (npm unpublish -f --registry http://localhost:4873 && %s))" +
+                                    "\"",
+                            "  }",
+                            "}"),
+
+                      getNpmPackageName(),
+                      version,
+                      dependenciesPart,
+                      Boolean.getBoolean("ts-exporter.publish.skip"),
+                      publishCommand
+        );
+    }
+
+    @Override
+    public String getNpmPackageName() {
+        return npmPackage.getName() + (npmPackage.getType().equals(FINAL) ? "-final" : "");
+    }
+}

--- a/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/model/config/PackageJsonRoot.java
+++ b/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/model/config/PackageJsonRoot.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter.model.config;
+
+import org.uberfire.jsbridge.tsexporter.model.TsExporterResource;
+
+import static java.lang.String.format;
+import static org.uberfire.jsbridge.tsexporter.util.Utils.lines;
+
+public class PackageJsonRoot implements TsExporterResource {
+
+    private final String appformerJsVersion;
+
+    public PackageJsonRoot(final String appformerJsVersion) {
+        this.appformerJsVersion = appformerJsVersion;
+    }
+
+    @Override
+    public String toSource() {
+        return format(lines(
+                "{",
+                "  \"name\": \"%s\",",
+                "  \"private\": true,",
+                "  \"license\": \"Apache-2.0\",",
+                "  \"dependencies\": {",
+                "    \"appformer-js\": \"^" + appformerJsVersion + "\"",
+                "  },",
+                "  \"workspaces\": [\"packages/*\"],",
+                "  \"scripts\": {",
+                "    \"build:ts-exporter\": \"" +
+                        "yarn install --registry http://localhost:4873 --no-lockfile && " +
+                        "npx lerna exec --concurrency `nproc || sysctl -n hw.ncpu` -- yarn run build:ts-exporter" +
+                        "\""
+                , "},",
+                "  \"devDependencies\": {",
+                "    \"circular-dependency-plugin\": \"^5.0.2\",",
+                "    \"clean-webpack-plugin\": \"^0.1.19\",",
+                "    \"ts-loader\": \"^4.4.2\",",
+                "    \"typescript\": \"^2.9.2\",",
+                "    \"webpack\": \"^4.15.1\",",
+                "    \"webpack-cli\": \"^3.0.8\",",
+                "    \"lerna\": \"^3.4.0\"",
+                "  }",
+                "}"),
+
+                      getNpmPackageName());
+    }
+
+    @Override
+    public String getNpmPackageName() {
+        return "ts-exporter-build-root";
+    }
+}

--- a/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/model/config/TsConfigJson.java
+++ b/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/model/config/TsConfigJson.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter.model.config;
+
+import java.util.List;
+
+import org.uberfire.jsbridge.tsexporter.model.TsClass;
+import org.uberfire.jsbridge.tsexporter.model.TsExporterResource;
+
+import static org.uberfire.jsbridge.tsexporter.util.Utils.lines;
+
+public class TsConfigJson implements TsExporterResource {
+
+    private final String npmPackageName;
+
+    public TsConfigJson(final String npmPackageName) {
+        this.npmPackageName = npmPackageName;
+    }
+
+    @Override
+    public String toSource() {
+        return lines(
+                "{",
+                "  \"exclude\": [\"./node_modules\"],",
+                "  \"include\": [\"./src\"],",
+                "  \"compilerOptions\": {",
+                "    \"lib\": [\"es6\", \"dom\"],",
+                "    \"module\": \"commonjs\",",
+                "    \"target\": \"es5\",",
+                "    \"declaration\": true,",
+                "    \"sourceMap\": true,",
+                "    \"outDir\": \"./\",",
+                "    \"noImplicitAny\": true,",
+                "    \"strictNullChecks\": true,",
+                "    \"experimentalDecorators\": true,",
+                "    \"noErrorTruncation\": true",
+                "  }",
+                "}"
+        );
+    }
+
+    @Override
+    public String getNpmPackageName() {
+        return npmPackageName;
+    }
+}

--- a/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/model/config/WebpackConfigJs.java
+++ b/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/model/config/WebpackConfigJs.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter.model.config;
+
+import org.uberfire.jsbridge.tsexporter.model.TsExporterResource;
+
+import static java.lang.String.format;
+import static org.uberfire.jsbridge.tsexporter.util.Utils.get;
+import static org.uberfire.jsbridge.tsexporter.util.Utils.lines;
+
+public class WebpackConfigJs implements TsExporterResource {
+
+    private final String npmPackageName;
+
+    public WebpackConfigJs(final String npmPackageName) {
+        this.npmPackageName = npmPackageName;
+    }
+
+    @Override
+    public String toSource() {
+
+        return format(lines(
+                "const path = require('path');",
+                "const CleanWebpackPlugin = require('clean-webpack-plugin');",
+                "const CircularDependencyPlugin = require('circular-dependency-plugin');",
+                "",
+                "module.exports = {",
+                "  mode: 'production',",
+                "  externals: [{",
+                "    'appformer-js': {",
+                "      root: 'AppFormer', //indicates global variable",
+                "      commonjs: 'appformer-js',",
+                "      commonjs2: 'appformer-js',",
+                "      amd: 'appformer-js'",
+                "    }",
+                "  }, function(context, request, callback) { ",
+                "       return request.startsWith('.') ? callback() : callback(null, 'umd ' + request); ",
+                "  }],",
+                "  entry: {",
+                "    '%s': './src/index.ts'",
+                "  },",
+                "  output: {",
+                "    path: path.resolve(__dirname, 'dist'),",
+                "    filename: 'index.js',",
+                "    library: '%s',",
+                "    libraryTarget: 'umd',",
+                "    umdNamedDefine: true",
+                "  },",
+                "  plugins: [",
+                "    new CleanWebpackPlugin(['dist']),",
+                "    new CircularDependencyPlugin({",
+                "      exclude: /node_modules/, // exclude detection of files based on a RegExp",
+                "      failOnError: false, // add errors to webpack instead of warnings",
+                "      cwd: process.cwd() // set the current working directory for displaying module paths",
+                "    })",
+                "  ],",
+                "  module: {",
+                "    rules: [",
+                "      {",
+                "        test: /\\.ts$/,",
+                "        loader: 'ts-loader'",
+                "      }",
+                "    ]",
+                "  },",
+                "  resolve: {",
+                "    extensions: ['.ts'],",
+                "    modules: [path.resolve('../../node_modules'), path.resolve('./node_modules'), path.resolve('./src')]",
+                "  }",
+                "};",
+                ""),
+
+                      get(-1, npmPackageName.split("/")),
+                      get(-1, npmPackageName.replace("-", "").split("/")));
+    }
+
+    @Override
+    public String getNpmPackageName() {
+        return npmPackageName;
+    }
+}

--- a/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/util/ElementUtils.java
+++ b/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/util/ElementUtils.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter.util;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+
+import static java.util.stream.Collectors.toList;
+import static javax.lang.model.element.Modifier.STATIC;
+
+public final class ElementUtils {
+
+    public static List<Element> getAllNonStaticFields(final TypeElement typeElement) {
+
+        final List<Element> currentTypeFields = nonStaticFieldsIn(typeElement.getEnclosedElements());
+
+        if (typeElement.getSuperclass().toString().equals("java.lang.Object")) {
+            return currentTypeFields;
+        }
+
+        final TypeElement superElement = (TypeElement) ((DeclaredType) typeElement.getSuperclass()).asElement();
+        final List<Element> inheritedTypeFields = getAllNonStaticFields(superElement);
+
+        return Stream.concat(inheritedTypeFields.stream(), currentTypeFields.stream()).collect(toList());
+    }
+
+    public static List<Element> nonStaticFieldsIn(final List<? extends Element> elements) {
+        return elements.stream()
+                .filter(e -> e.getKind().isField())
+                .filter(e -> !e.getModifiers().contains(STATIC))
+                .filter(e -> !e.asType().toString().contains("java.util.function"))
+                .collect(toList());
+    }
+}

--- a/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/util/IndirectHashMap.java
+++ b/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/util/IndirectHashMap.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter.util;
+
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import static java.util.stream.Collectors.toSet;
+import static org.uberfire.jsbridge.tsexporter.util.Utils.distinctBy;
+
+public class IndirectHashMap<DK, V> {
+
+    private final Function<DK, ?> keyMapper;
+    private final Map<Object, V> map = new HashMap<>();
+    private final Set<DK> directKeys = new HashSet<>();
+
+    public IndirectHashMap(final Function<DK, ?> keyMapper) {
+        this.keyMapper = keyMapper;
+    }
+
+    public V get(final DK directKey) {
+        return map.get(keyMapper.apply(directKey));
+    }
+
+    private Set<DK> keySet() {
+        return directKeys.stream()
+                .filter(distinctBy(keyMapper))
+                .collect(toSet());
+    }
+
+    public V merge(final DK directKey,
+                   final V value,
+                   final BiFunction<V, V, V> mergeFunction) {
+
+        final V merged = map.merge(keyMapper.apply(directKey), value, mergeFunction);
+        if (merged != null) {
+            directKeys.add(directKey);
+        } else {
+            directKeys.remove(directKey);
+        }
+        return merged;
+    }
+
+    public Set<Map.Entry<DK, V>> entrySet() {
+        return keySet().stream()
+                .map(dk -> new SimpleImmutableEntry<>(dk, map.get(keyMapper.apply(dk))))
+                .collect(toSet());
+    }
+}

--- a/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/util/Lazy.java
+++ b/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/util/Lazy.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter.util;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Supplier;
+
+public class Lazy<T> {
+
+    private final Supplier<T> delegate;
+    private final ConcurrentMap<Class<?>, T> map = new ConcurrentHashMap<>(1);
+
+    public Lazy(final Supplier<T> delegate) {
+        this.delegate = delegate;
+    }
+
+    public T get() {
+        return map.computeIfAbsent(Lazy.class, k -> delegate.get());
+    }
+}

--- a/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/util/Utils.java
+++ b/packages/ts-exporter/src/main/java/org/uberfire/jsbridge/tsexporter/util/Utils.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter.util;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Scanner;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+import static java.lang.String.format;
+import static java.util.Arrays.stream;
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toSet;
+import static java.util.stream.Stream.concat;
+
+public class Utils {
+
+    public static Path createFileIfNotExists(final Path path) throws IOException {
+        return path.toFile().exists() ? path : Files.createFile(path);
+    }
+
+    public static <T> Predicate<T> distinctBy(final Function<? super T, ?> keyExtractor) {
+        final Set<Object> seen = ConcurrentHashMap.newKeySet();
+        return t -> seen.add(keyExtractor.apply(t));
+    }
+
+    public static String lines(final String... lines) {
+        return linesJoinedBy("\n", lines);
+    }
+
+    public static String linesJoinedBy(final String joiner, final String[] lines) {
+        return stream(lines).collect(joining(joiner));
+    }
+
+    @SafeVarargs
+    public static String formatRightToLeft(final String lines, final Supplier<String>... args) {
+        return format(lines, reverse(stream(reverse(args)).map(Supplier::get).<Object>toArray(String[]::new)));
+    }
+
+    private static <T> T[] reverse(final T[] array) {
+        for (int i = 0; i < array.length / 2; i++) {
+            T temp = array[i];
+            array[i] = array[array.length - i - 1];
+            array[array.length - i - 1] = temp;
+        }
+        return array;
+    }
+
+    public static Properties loadPropertiesFile(final URL fileUrl) {
+        final Properties properties = new Properties();
+        try {
+            properties.load(fileUrl.openStream());
+        } catch (final IOException e) {
+            throw new RuntimeException("Failed to load properties file " + fileUrl, e);
+        }
+        return properties;
+    }
+
+    public static <T> T get(final int a, final T[] array) {
+        return array[a < 0 ? array.length + a : a];
+    }
+
+    public static Enumeration<URL> getResources(final String resourceName) {
+        try {
+            return Utils.class.getClassLoader().getResources(resourceName);
+        } catch (final IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static <T> Set<T> diff(final Set<? extends T> a,
+                                  final Set<? extends T> b) {
+
+        final Set<T> tmp = new HashSet<>(a);
+        tmp.removeAll(b);
+        return tmp;
+    }
+
+    public static <T> Set<T> mergeSets(final Set<T> a, final Set<T> b) {
+        return concat(a.stream(), b.stream()).collect(toSet());
+    }
+
+    public static String readClasspathResource(final URL url) {
+        String contents;
+        try (final Scanner scanner = new Scanner(url.openStream()).useDelimiter("\\A")) {
+            contents = scanner.hasNext() ? scanner.next() : "";
+        } catch (final Exception e) {
+            throw new RuntimeException(e);
+        }
+        return contents;
+    }
+}

--- a/packages/ts-exporter/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/packages/ts-exporter/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,0 +1,1 @@
+org.uberfire.jsbridge.tsexporter.Main

--- a/packages/ts-exporter/src/test/java/org/uberfire/jsbridge/tsexporter/dependency/DependencyGraphTest.java
+++ b/packages/ts-exporter/src/test/java/org/uberfire/jsbridge/tsexporter/dependency/DependencyGraphTest.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter.dependency;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import javax.lang.model.element.Element;
+
+import com.google.testing.compile.CompilationRule;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.uberfire.jsbridge.tsexporter.util.TestingUtils;
+
+import static java.util.Arrays.stream;
+import static java.util.Collections.singleton;
+import static java.util.Comparator.comparing;
+import static java.util.stream.Collectors.toList;
+import static org.junit.Assert.assertEquals;
+import static org.uberfire.jsbridge.tsexporter.decorators.DecoratorStore.NO_DECORATORS;
+import static org.uberfire.jsbridge.tsexporter.util.TestingUtils.element;
+import static org.uberfire.jsbridge.tsexporter.util.TestingUtils.memberElement;
+import static org.uberfire.jsbridge.tsexporter.util.TestingUtils.type;
+
+public class DependencyGraphTest {
+
+    @Rule
+    public final CompilationRule compilationRule = new CompilationRule();
+
+    @Before
+    public void before() {
+        TestingUtils.init(compilationRule.getTypes(), compilationRule.getElements());
+    }
+
+    class X {
+
+        X field;
+    }
+
+    @Test
+    public void testInvalidElements() {
+        final DependencyGraph graph = new DependencyGraph(Stream.empty(), NO_DECORATORS);
+        assertEquals(null, graph.add(null));
+        assertEquals(0, graph.vertices().size());
+        assertEquals(null, graph.add(memberElement("field", type(X.class))));
+        assertEquals(0, graph.vertices().size());
+
+        assertEquals(list(), ordered(graph.findAllDependencies(null)));
+        assertEquals(list(), ordered(graph.findAllDependents(null)));
+        assertEquals(list(), ordered(graph.findAllDependencies(singleton(memberElement("field", type(X.class))))));
+        assertEquals(list(), ordered(graph.findAllDependents(singleton(memberElement("field", type(X.class))))));
+    }
+
+    interface A0 {
+
+    }
+
+    interface A1 extends A0 {
+
+    }
+
+    interface A2 extends A1 {
+
+    }
+
+    interface A1B1 extends A0,
+                           B0 {
+
+    }
+
+    interface B0 {
+
+    }
+
+    interface A2B1 extends A1,
+                           B0 {
+
+    }
+
+    @Test
+    public void testSimpleGraphVertices() {
+        final DependencyGraph graph = new DependencyGraph(Stream.empty(), NO_DECORATORS);
+        graph.add(element(A0.class));
+        assertEquals(1, graph.vertices().size());
+        graph.add(element(A1.class));
+        assertEquals(2, graph.vertices().size());
+        graph.add(element(A2.class));
+        assertEquals(3, graph.vertices().size());
+
+        assertEquals(list(), simpleNames(graph.vertex(element(A0.class)).dependencies.keySet()));
+        assertEquals(list("A0"), simpleNames(graph.vertex(element(A1.class)).dependencies.keySet()));
+        assertEquals(list("A1"), simpleNames(graph.vertex(element(A2.class)).dependencies.keySet()));
+
+        assertEquals(list("A1"), simpleNames(graph.vertex(element(A0.class)).dependents.keySet()));
+        assertEquals(list("A2"), simpleNames(graph.vertex(element(A1.class)).dependents.keySet()));
+        assertEquals(list(), simpleNames(graph.vertex(element(A2.class)).dependents.keySet()));
+    }
+
+    @Test
+    public void testGraphVerticesComplex() {
+        final DependencyGraph graph = new DependencyGraph(Stream.empty(), NO_DECORATORS);
+        graph.add(element(A2B1.class));
+        assertEquals(4, graph.vertices().size());
+        graph.add(element(A1.class));
+        assertEquals(4, graph.vertices().size());
+        graph.add(element(B0.class));
+        assertEquals(4, graph.vertices().size());
+        graph.add(element(A1B1.class));
+        assertEquals(5, graph.vertices().size());
+        graph.add(element(A0.class));
+        assertEquals(5, graph.vertices().size());
+        graph.add(element(A2.class));
+        assertEquals(6, graph.vertices().size());
+
+        assertEquals(list(), simpleNames(graph.vertex(element(A0.class)).dependencies.keySet()));
+        assertEquals(list("A0"), simpleNames(graph.vertex(element(A1.class)).dependencies.keySet()));
+        assertEquals(list("A0", "B0"), simpleNames(graph.vertex(element(A1B1.class)).dependencies.keySet()));
+        assertEquals(list("A1"), simpleNames(graph.vertex(element(A2.class)).dependencies.keySet()));
+        assertEquals(list("A1", "B0"), simpleNames(graph.vertex(element(A2B1.class)).dependencies.keySet()));
+        assertEquals(list(), simpleNames(graph.vertex(element(B0.class)).dependencies.keySet()));
+
+        assertEquals(list("A1", "A1B1"), simpleNames(graph.vertex(element(A0.class)).dependents.keySet()));
+        assertEquals(list("A2", "A2B1"), simpleNames(graph.vertex(element(A1.class)).dependents.keySet()));
+        assertEquals(list(), simpleNames(graph.vertex(element(A1B1.class)).dependents.keySet()));
+        assertEquals(list(), simpleNames(graph.vertex(element(A2.class)).dependents.keySet()));
+        assertEquals(list(), simpleNames(graph.vertex(element(A2B1.class)).dependents.keySet()));
+        assertEquals(list("A1B1", "A2B1"), simpleNames(graph.vertex(element(B0.class)).dependents.keySet()));
+    }
+
+    class c0 {
+
+        c1 field;
+    }
+
+    class c1 {
+
+        c0 field;
+    }
+
+    @Test
+    public void testCycle() {
+        final DependencyGraph graph = new DependencyGraph(Stream.empty(), NO_DECORATORS);
+        graph.add(element(c0.class));
+        assertEquals(2, graph.vertices().size());
+        graph.add(element(c1.class));
+        assertEquals(2, graph.vertices().size());
+
+        assertEquals(list("c0", "c1"), simpleNames(graph.findAllDependencies(singleton(element(c0.class)))));
+        assertEquals(list("c0", "c1"), simpleNames(graph.findAllDependencies(singleton(element(c1.class)))));
+
+        assertEquals(list("c0", "c1"), simpleNames(graph.findAllDependents(singleton(element(c0.class)))));
+        assertEquals(list("c0", "c1"), simpleNames(graph.findAllDependents(singleton(element(c1.class)))));
+    }
+
+    class a2b2 implements A1B1 {
+
+        a3b2 field;
+    }
+
+    class a3b2 implements A2B1 {
+
+        a2b2 field;
+    }
+
+    @Test
+    public void testCycleComplex() {
+        final DependencyGraph graph = new DependencyGraph(Stream.empty(), NO_DECORATORS);
+        graph.add(element(a2b2.class));
+        assertEquals(7, graph.vertices().size());
+        graph.add(element(a3b2.class));
+        assertEquals(7, graph.vertices().size());
+
+        assertEquals(list("A0"), simpleNames(graph.findAllDependencies(singleton(element(A0.class)))));
+        assertEquals(list("A0", "A1"), simpleNames(graph.findAllDependencies(singleton(element(A1.class)))));
+        assertEquals(list("A0", "A1B1", "B0"), simpleNames(graph.findAllDependencies(singleton(element(A1B1.class)))));
+        assertEquals(list("A0", "A1", "A2B1", "B0"), simpleNames(graph.findAllDependencies(singleton(element(A2B1.class)))));
+        assertEquals(list("B0"), simpleNames(graph.findAllDependencies(singleton(element(B0.class)))));
+        assertEquals(list("A0", "A1", "A1B1", "A2B1", "B0", "a2b2", "a3b2"), simpleNames(graph.findAllDependencies(singleton(element(a2b2.class)))));
+        assertEquals(list("A0", "A1", "A1B1", "A2B1", "B0", "a2b2", "a3b2"), simpleNames(graph.findAllDependencies(singleton(element(a3b2.class)))));
+
+        assertEquals(list("A0", "A1", "A1B1", "A2B1", "a2b2", "a3b2"), simpleNames(graph.findAllDependents(singleton(element(A0.class)))));
+        assertEquals(list("A1", "A2B1", "a2b2", "a3b2"), simpleNames(graph.findAllDependents(singleton(element(A1.class)))));
+        assertEquals(list("A1B1", "a2b2", "a3b2"), simpleNames(graph.findAllDependents(singleton(element(A1B1.class)))));
+        assertEquals(list("A2B1", "a2b2", "a3b2"), simpleNames(graph.findAllDependents(singleton(element(A2B1.class)))));
+        assertEquals(list("A1B1", "A2B1", "B0", "a2b2", "a3b2"), simpleNames(graph.findAllDependents(singleton(element(B0.class)))));
+        assertEquals(list("a2b2", "a3b2"), simpleNames(graph.findAllDependents(singleton(element(a2b2.class)))));
+        assertEquals(list("a2b2", "a3b2"), simpleNames(graph.findAllDependents(singleton(element(a3b2.class)))));
+    }
+
+    private static List<String> simpleNames(final Set<DependencyGraph.Vertex> vertex) {
+        return ordered(vertex).stream().map(s -> s.asElement().getSimpleName().toString()).collect(toList());
+    }
+
+    private static <T> List<T> ordered(final Set<T> set) {
+        return set.stream().sorted(comparing(Object::toString)).collect(toList());
+    }
+
+    @SafeVarargs
+    private static <T> List<T> list(final T... ts) {
+        return stream(ts).collect(toList());
+    }
+}

--- a/packages/ts-exporter/src/test/java/org/uberfire/jsbridge/tsexporter/meta/JavaTypeTest.java
+++ b/packages/ts-exporter/src/test/java/org/uberfire/jsbridge/tsexporter/meta/JavaTypeTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter.meta;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.lang.model.type.DeclaredType;
+
+import com.google.testing.compile.CompilationRule;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.uberfire.jsbridge.tsexporter.dependency.DependencyRelation;
+import org.uberfire.jsbridge.tsexporter.dependency.ImportEntry;
+import org.uberfire.jsbridge.tsexporter.dependency.ImportEntriesStore;
+import org.uberfire.jsbridge.tsexporter.model.PojoTsClass;
+import org.uberfire.jsbridge.tsexporter.util.TestingUtils;
+
+import static java.util.Comparator.comparing;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.uberfire.jsbridge.tsexporter.decorators.DecoratorStore.NO_DECORATORS;
+import static org.uberfire.jsbridge.tsexporter.dependency.DependencyRelation.Kind.FIELD;
+import static org.uberfire.jsbridge.tsexporter.dependency.DependencyRelation.Kind.HIERARCHY;
+import static org.uberfire.jsbridge.tsexporter.util.TestingUtils.member;
+import static org.uberfire.jsbridge.tsexporter.util.TestingUtils.type;
+
+public class JavaTypeTest {
+
+    @Rule
+    public final CompilationRule compilationRule = new CompilationRule();
+
+    @Before
+    public void before() {
+        TestingUtils.init(compilationRule.getTypes(), compilationRule.getElements());
+    }
+
+    @Test
+    public void testAggregated() {
+
+        final PojoTsClass tsClass = new PojoTsClass(type(JavaTypeTest.class), NO_DECORATORS);
+        final ImportEntriesStore store = new ImportEntriesStore(tsClass);
+
+        final List<ImportEntry> aggregated0 = store.with(
+                FIELD, member("field2", type(TestingUtils.Sphere.class)).translate(NO_DECORATORS))
+                .getAggregatedImportEntries();
+        assertEquals(2, aggregated0.size());
+        assertTrue(aggregated0.get(0).toString().endsWith("Circle<T>"));
+        assertTrue(aggregated0.get(1).toString().endsWith("Sphere<J>"));
+
+        final List<ImportEntry> aggregated1 = store.with(
+                HIERARCHY, translatable(type(TestingUtils.Circle.class)))
+                .getAggregatedImportEntries();
+        assertEquals(2, aggregated1.size());
+        assertTrue(aggregated1.get(0).toString().endsWith("Circle<T>"));
+        assertTrue(aggregated1.get(1).toString().endsWith("Circle<T>"));
+
+        final List<ImportEntry> aggregated2 = store.with(
+                HIERARCHY, translatable(type(TestingUtils.Circle.class)))
+                .getAggregatedImportEntries();
+        assertEquals(2, aggregated2.size());
+        assertTrue(aggregated2.get(0).toString().endsWith("Circle<T>"));
+
+        List<ImportEntry> aggregated3 = store.with(
+                HIERARCHY, member("get6", type(TestingUtils.Circle.class)).translate(NO_DECORATORS))
+                .getAggregatedImportEntries();
+        assertEquals(3, aggregated3.size());
+        assertTrue(aggregated3.get(0).toString().endsWith("Circle<T>"));
+
+        final List<ImportEntry> importEntries = store.getImports().stream()
+                .map(DependencyRelation::getImportEntry)
+                .sorted(comparing(ImportEntry::sourcePath))
+                .collect(Collectors.toList());
+
+        assertEquals(2, importEntries.size());
+        assertTrue(importEntries.get(0).toString().endsWith("Circle<T>"));
+        assertTrue(importEntries.get(1).toString().endsWith("Sphere<J>"));
+    }
+
+    private Translatable translatable(final DeclaredType type) {
+        return new JavaType(type, type).translate(NO_DECORATORS);
+    }
+}

--- a/packages/ts-exporter/src/test/java/org/uberfire/jsbridge/tsexporter/meta/TranslatableTest.java
+++ b/packages/ts-exporter/src/test/java/org/uberfire/jsbridge/tsexporter/meta/TranslatableTest.java
@@ -1,0 +1,307 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter.meta;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeMirror;
+
+import com.google.testing.compile.CompilationRule;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.uberfire.jsbridge.tsexporter.decorators.DecoratorStore;
+import org.uberfire.jsbridge.tsexporter.decorators.ImportEntryForDecorator;
+import org.uberfire.jsbridge.tsexporter.meta.Translatable.SourceUsage;
+
+import static java.util.Collections.singleton;
+import static javax.lang.model.type.TypeKind.BOOLEAN;
+import static javax.lang.model.type.TypeKind.BYTE;
+import static javax.lang.model.type.TypeKind.CHAR;
+import static javax.lang.model.type.TypeKind.DOUBLE;
+import static javax.lang.model.type.TypeKind.FLOAT;
+import static javax.lang.model.type.TypeKind.INT;
+import static javax.lang.model.type.TypeKind.LONG;
+import static javax.lang.model.type.TypeKind.SHORT;
+import static javax.lang.model.type.TypeKind.VOID;
+import static org.junit.Assert.assertEquals;
+import static org.uberfire.jsbridge.tsexporter.decorators.DecoratorStore.NO_DECORATORS;
+import static org.uberfire.jsbridge.tsexporter.meta.Translatable.SourceUsage.IMPORT_STATEMENT;
+import static org.uberfire.jsbridge.tsexporter.meta.Translatable.SourceUsage.TYPE_ARGUMENT_DECLARATION;
+import static org.uberfire.jsbridge.tsexporter.meta.Translatable.SourceUsage.TYPE_ARGUMENT_USE;
+import static org.uberfire.jsbridge.tsexporter.util.TestingUtils.Circle;
+import static org.uberfire.jsbridge.tsexporter.util.TestingUtils.Cylinder;
+import static org.uberfire.jsbridge.tsexporter.util.TestingUtils.DeclaredTypes;
+import static org.uberfire.jsbridge.tsexporter.util.TestingUtils.Foo;
+import static org.uberfire.jsbridge.tsexporter.util.TestingUtils.Sphere;
+import static org.uberfire.jsbridge.tsexporter.util.TestingUtils.array;
+import static org.uberfire.jsbridge.tsexporter.util.TestingUtils.erased;
+import static org.uberfire.jsbridge.tsexporter.util.TestingUtils.init;
+import static org.uberfire.jsbridge.tsexporter.util.TestingUtils.member;
+import static org.uberfire.jsbridge.tsexporter.util.TestingUtils.param;
+import static org.uberfire.jsbridge.tsexporter.util.TestingUtils.primitive;
+import static org.uberfire.jsbridge.tsexporter.util.TestingUtils.type;
+import static org.uberfire.jsbridge.tsexporter.util.TestingUtils.types;
+import static org.uberfire.jsbridge.tsexporter.util.TestingUtils.wildcard;
+
+public class TranslatableTest {
+
+    @Rule
+    public final CompilationRule compilationRule = new CompilationRule();
+
+    @Before
+    public void before() {
+        init(compilationRule.getTypes(), compilationRule.getElements());
+        JavaType.SIMPLE_NAMES.set(true);
+    }
+
+    @After
+    public void after() {
+        JavaType.SIMPLE_NAMES.set(false);
+    }
+
+    @Test
+    public void testPrimitives() {
+        assertEquals("JavaInteger", translate(primitive(INT)));
+        assertEquals("JavaByte", translate(primitive(BYTE)));
+        assertEquals("JavaDouble", translate(primitive(DOUBLE)));
+        assertEquals("JavaFloat", translate(primitive(FLOAT)));
+        assertEquals("JavaShort", translate(primitive(SHORT)));
+        assertEquals("JavaLong", translate(primitive(LONG)));
+        assertEquals("void", translate(types.getNoType(VOID)));
+        assertEquals("string", translate(primitive(CHAR)));
+        assertEquals("boolean", translate(primitive(BOOLEAN)));
+        assertEquals("null", translate(types.getNullType()));
+    }
+
+    @Test
+    public void testArray() {
+        assertEquals("JavaInteger[]", translate(array(primitive(INT))));
+        assertEquals("JavaInteger[][]", translate(array(array(primitive(INT)))));
+        assertEquals("string[]", translate(array(type(String.class))));
+        assertEquals("Map<any, any>[]", translate(array(erased(type(Map.class)))));
+        assertEquals("Array<E>[]", translate(array(type(List.class))));
+        assertEquals("Array<any>[]", translate(array(erased(type(List.class)))));
+    }
+
+    @Test
+    public void testTypeVar() {
+        assertEquals("Circle<T extends Circle<T>>", translate(type(Circle.class)));
+        assertEquals("Circle<T>", translate(TYPE_ARGUMENT_USE, type(Circle.class)));
+        assertEquals("T extends Circle<T>", translate(member("field1", type(Circle.class))));
+        assertEquals("T", translate(TYPE_ARGUMENT_USE, member("field1", type(Circle.class))));
+        assertEquals("Circle<T extends Circle<T>>", translate(member("field2", type(Circle.class))));
+        assertEquals("Circle<T>", translate(TYPE_ARGUMENT_USE, member("field2", type(Circle.class))));
+        assertEquals("T", translate(TYPE_ARGUMENT_USE, param(0, member("get1", type(Circle.class)))));
+        assertEquals("U", translate(TYPE_ARGUMENT_USE, param(1, member("get2", type(Circle.class)))));
+
+        assertEquals("Cylinder", translate(type(Cylinder.class)));
+        assertEquals("Cylinder", translate(TYPE_ARGUMENT_USE, type(Cylinder.class)));
+        assertEquals("Circle<Cylinder>", translate(((TypeElement) type(Cylinder.class).asElement()).getSuperclass()));
+        assertEquals("Circle<Cylinder>", translate(TYPE_ARGUMENT_USE, ((TypeElement) type(Cylinder.class).asElement()).getSuperclass()));
+        assertEquals("Cylinder", translate(member("field1", type(Cylinder.class))));
+        assertEquals("Cylinder", translate(TYPE_ARGUMENT_USE, member("field1", type(Cylinder.class))));
+        assertEquals("Circle<Cylinder>", translate(member("field2", type(Cylinder.class))));
+        assertEquals("Circle<Cylinder>", translate(TYPE_ARGUMENT_USE, member("field2", type(Cylinder.class))));
+        assertEquals("Cylinder", translate(TYPE_ARGUMENT_USE, param(0, member("get1", type(Cylinder.class)))));
+        assertEquals("Cylinder", translate(TYPE_ARGUMENT_USE, param(0, member("get2", type(Cylinder.class)))));
+        assertEquals("U", translate(TYPE_ARGUMENT_USE, param(1, member("get2", type(Cylinder.class)))));
+
+        assertEquals("Sphere<J>", translate(type(Sphere.class)));
+        assertEquals("Sphere<J>", translate(TYPE_ARGUMENT_USE, type(Sphere.class)));
+        assertEquals("Circle<Sphere<J>>", translate(((TypeElement) type(Sphere.class).asElement()).getSuperclass()));
+        assertEquals("Circle<Sphere<J>>", translate(TYPE_ARGUMENT_USE, ((TypeElement) type(Sphere.class).asElement()).getSuperclass()));
+        assertEquals("Sphere<J>", translate(member("field1", type(Sphere.class))));
+        assertEquals("Sphere<J>", translate(TYPE_ARGUMENT_USE, member("field1", type(Sphere.class))));
+        assertEquals("Circle<Sphere<J>>", translate(member("field2", type(Sphere.class))));
+        assertEquals("Circle<Sphere<J>>", translate(TYPE_ARGUMENT_USE, member("field2", type(Sphere.class))));
+        assertEquals("Sphere<J>", translate(TYPE_ARGUMENT_USE, param(0, member("get1", type(Sphere.class)))));
+        assertEquals("Sphere<J>", translate(TYPE_ARGUMENT_USE, param(0, member("get2", type(Sphere.class)))));
+        assertEquals("U", translate(TYPE_ARGUMENT_USE, param(1, member("get2", type(Sphere.class)))));
+    }
+
+    @Test
+    public void testDecorated() {
+        final ImportEntryForDecorator dependency = new ImportEntryForDecorator(
+                "my-pojos", "my-decorators",
+                "my-decorators/decorators/Bar",
+                Foo.class.getCanonicalName());
+
+        final Translatable translatable = new JavaType(type(Foo.class), type(Foo.class))
+                .translate(new DecoratorStore(singleton(dependency)));
+
+        assertEquals("mydecorators_decorators_Bar", translatable.toTypeScript(TYPE_ARGUMENT_DECLARATION));
+        assertEquals(1, translatable.getAggregatedImportEntries().size());
+        assertEquals(dependency, translatable.getAggregatedImportEntries().get(0));
+    }
+
+    @Test
+    public void testDeclared() {
+        assertEquals("any /* object */", translate(type(Object.class)));
+        assertEquals("any /* date */", translate(type(Date.class)));
+        assertEquals("any /* stack trace element */", translate(type(StackTraceElement.class)));
+        assertEquals("any /* throwable */", translate(type(Throwable.class)));
+        //TODO: javax.enterprise.event.Event: WHY?
+        assertEquals("boolean", translate(type(Boolean.class)));
+        assertEquals("string", translate(type(Character.class)));
+        assertEquals("string", translate(type(String.class)));
+        assertEquals("JavaInteger", translate(type(Integer.class)));
+        assertEquals("JavaByte", translate(type(Byte.class)));
+        assertEquals("JavaDouble", translate(type(Double.class)));
+        assertEquals("JavaFloat", translate(type(Float.class)));
+        assertEquals("JavaLong", translate(type(Long.class)));
+        assertEquals("JavaNumber", translate(type(Number.class)));
+        assertEquals("JavaShort", translate(type(Short.class)));
+        assertEquals("JavaBigInteger", translate(type(BigInteger.class)));
+        assertEquals("JavaBigDecimal", translate(type(BigDecimal.class)));
+        assertEquals("number", translate(type(OptionalInt.class)));
+        assertEquals("any /* class */", translate(type(Class.class)));
+        assertEquals("any /* enum_ */", translate(type(Enum.class)));
+        assertEquals("any /* map entry */", translate(type(Map.Entry.class)));
+        //TODO: HashMap.Node: It's protected! How?
+        assertEquals("JavaTreeMap<any, any>", translate(erased(type(TreeMap.class))));
+        assertEquals("Map<any, any>", translate(erased(type(HashMap.class))));
+        assertEquals("Map<any, any>", translate(erased(type(Map.class))));
+        assertEquals("Set<any>", translate(erased(type(Set.class))));
+        assertEquals("Set<any>", translate(erased(type(HashSet.class))));
+        assertEquals("JavaTreeSet<any>", translate(erased(type(TreeSet.class))));
+        assertEquals("Array<any>", translate(erased(type(List.class))));
+        assertEquals("Array<any>", translate(erased(type(ArrayList.class))));
+        assertEquals("JavaLinkedList<any>", translate(erased(type(LinkedList.class))));
+        assertEquals("Array<any>", translate(erased(type(Collection.class))));
+        assertEquals("Array", translate(IMPORT_STATEMENT, erased(type(Collection.class))));
+        assertEquals("Foo", translate(type(Foo.class)));
+        assertEquals("Foo", translate(IMPORT_STATEMENT, type(Foo.class)));
+        assertEquals("Bar", translate(type(Foo.Bar.class)));
+        assertEquals("Bar", translate(IMPORT_STATEMENT, type(Foo.Bar.class)));
+        assertEquals("Circle<any>", translate(erased(type(Circle.class))));
+        assertEquals("Circle", translate(IMPORT_STATEMENT, erased(type(Circle.class))));
+        assertEquals("JavaOptional<any>", translate(erased(type(Optional.class))));
+
+        assertEquals("Map<string, string>", translate(member("map", type(DeclaredTypes.class))));
+        assertEquals("JavaTreeMap<string, string>", translate(member("treeMap", type(DeclaredTypes.class))));
+        assertEquals("Set<string>", translate(member("set", type(DeclaredTypes.class))));
+        assertEquals("Set<string>", translate(member("hashSet", type(DeclaredTypes.class))));
+        assertEquals("JavaTreeSet<string>", translate(member("treeSet", type(DeclaredTypes.class))));
+        assertEquals("Array<string>", translate(member("list", type(DeclaredTypes.class))));
+        assertEquals("Array<string>", translate(member("arrayList", type(DeclaredTypes.class))));
+        assertEquals("JavaLinkedList<string>", translate(member("linkedList", type(DeclaredTypes.class))));
+        assertEquals("Array<string>", translate(member("collection", type(DeclaredTypes.class))));
+        assertEquals("any /* class */", translate(member("clazz", type(DeclaredTypes.class))));
+        assertEquals("JavaOptional<string>", translate(member("optional", type(DeclaredTypes.class))));
+    }
+
+    @Test
+    public void testWildcard() {
+        assertEquals("any /* wildcard */", translate(wildcard(null, null)));
+        assertEquals("string", translate(wildcard(type(String.class), null)));
+        assertEquals("Partial<string>", translate(wildcard(null, type(String.class))));
+        assertEquals("Partial<Map<any, any>>", translate(wildcard(null, erased(type(Map.class)))));
+    }
+
+    @Test
+    public void testExecutable() {
+        assertEquals("", translate(member("get1", type(Circle.class))));
+        assertEquals("", translate(TYPE_ARGUMENT_USE, member("get1", type(Circle.class))));
+        assertEquals("", translate(IMPORT_STATEMENT, member("get1", type(Circle.class))));
+        assertEquals("<U>", translate(member("get2", type(Circle.class))));
+        assertEquals("<U>", translate(TYPE_ARGUMENT_USE, member("get2", type(Circle.class))));
+        assertEquals("", translate(IMPORT_STATEMENT, member("get2", type(Circle.class))));
+        assertEquals("<U extends T>", translate(member("get3", type(Circle.class))));
+        assertEquals("<U>", translate(TYPE_ARGUMENT_USE, member("get3", type(Circle.class))));
+        assertEquals("", translate(IMPORT_STATEMENT, member("get3", type(Circle.class))));
+        assertEquals("<U extends T, S extends U>", translate(member("get4", type(Circle.class))));
+        assertEquals("<U, S>", translate(TYPE_ARGUMENT_USE, member("get4", type(Circle.class))));
+        assertEquals("", translate(IMPORT_STATEMENT, member("get4", type(Circle.class))));
+        assertEquals("<U extends T, S extends Array<T>>", translate(member("get5", type(Circle.class))));
+        assertEquals("<U, S>", translate(TYPE_ARGUMENT_USE, member("get5", type(Circle.class))));
+        assertEquals("", translate(IMPORT_STATEMENT, member("get5", type(Circle.class))));
+        assertEquals("<U extends T, S extends Circle<T>>", translate(member("get6", type(Circle.class))));
+        assertEquals("<U, S>", translate(TYPE_ARGUMENT_USE, member("get6", type(Circle.class))));
+        assertEquals("", translate(IMPORT_STATEMENT, member("get6", type(Circle.class))));
+
+        assertEquals("", translate(member("get1", type(Cylinder.class))));
+        assertEquals("", translate(TYPE_ARGUMENT_USE, member("get1", type(Cylinder.class))));
+        assertEquals("", translate(IMPORT_STATEMENT, member("get1", type(Cylinder.class))));
+        assertEquals("<U>", translate(member("get2", type(Cylinder.class))));
+        assertEquals("<U>", translate(TYPE_ARGUMENT_USE, member("get2", type(Cylinder.class))));
+        assertEquals("", translate(IMPORT_STATEMENT, member("get2", type(Cylinder.class))));
+        assertEquals("<U extends Cylinder>", translate(member("get3", type(Cylinder.class))));
+        assertEquals("<U>", translate(TYPE_ARGUMENT_USE, member("get3", type(Cylinder.class))));
+        assertEquals("", translate(IMPORT_STATEMENT, member("get3", type(Cylinder.class))));
+        assertEquals("<U extends Cylinder, S extends U>", translate(member("get4", type(Cylinder.class))));
+        assertEquals("<U, S>", translate(TYPE_ARGUMENT_USE, member("get4", type(Cylinder.class))));
+        assertEquals("", translate(IMPORT_STATEMENT, member("get4", type(Cylinder.class))));
+        assertEquals("<U extends Cylinder, S extends Array<Cylinder>>", translate(member("get5", type(Cylinder.class))));
+        assertEquals("<U, S>", translate(TYPE_ARGUMENT_USE, member("get5", type(Cylinder.class))));
+        assertEquals("", translate(IMPORT_STATEMENT, member("get5", type(Cylinder.class))));
+        assertEquals("<U extends Cylinder, S extends Circle<Cylinder>>", translate(member("get6", type(Cylinder.class))));
+        assertEquals("<U, S>", translate(TYPE_ARGUMENT_USE, member("get6", type(Cylinder.class))));
+        assertEquals("", translate(IMPORT_STATEMENT, member("get6", type(Cylinder.class))));
+
+        assertEquals("", translate(member("get1", type(Sphere.class))));
+        assertEquals("", translate(TYPE_ARGUMENT_USE, member("get1", type(Sphere.class))));
+        assertEquals("", translate(IMPORT_STATEMENT, member("get1", type(Sphere.class))));
+        assertEquals("<U>", translate(member("get2", type(Sphere.class))));
+        assertEquals("<U>", translate(TYPE_ARGUMENT_USE, member("get2", type(Sphere.class))));
+        assertEquals("", translate(IMPORT_STATEMENT, member("get2", type(Sphere.class))));
+        assertEquals("<U extends Sphere<J>>", translate(member("get3", type(Sphere.class))));
+        assertEquals("<U>", translate(TYPE_ARGUMENT_USE, member("get3", type(Sphere.class))));
+        assertEquals("", translate(IMPORT_STATEMENT, member("get3", type(Sphere.class))));
+        assertEquals("<U extends Sphere<J>, S extends U>", translate(member("get4", type(Sphere.class))));
+        assertEquals("<U, S>", translate(TYPE_ARGUMENT_USE, member("get4", type(Sphere.class))));
+        assertEquals("", translate(IMPORT_STATEMENT, member("get4", type(Sphere.class))));
+        assertEquals("<U extends Sphere<J>, S extends Array<Sphere<J>>>", translate(member("get5", type(Sphere.class))));
+        assertEquals("<U, S>", translate(TYPE_ARGUMENT_USE, member("get5", type(Sphere.class))));
+        assertEquals("", translate(IMPORT_STATEMENT, member("get5", type(Sphere.class))));
+        assertEquals("<U extends Sphere<J>, S extends Circle<Sphere<J>>>", translate(member("get6", type(Sphere.class))));
+        assertEquals("<U, S>", translate(TYPE_ARGUMENT_USE, member("get6", type(Sphere.class))));
+        assertEquals("", translate(IMPORT_STATEMENT, member("get6", type(Sphere.class))));
+    }
+
+    private String translate(final TypeMirror type) {
+        return translate(new JavaType(type, type));
+    }
+
+    private String translate(final JavaType type) {
+        return translate(TYPE_ARGUMENT_DECLARATION, type);
+    }
+
+    private String translate(final SourceUsage sourceUsage, final TypeMirror type) {
+        return translate(sourceUsage, new JavaType(type, type));
+    }
+
+    private String translate(final SourceUsage sourceUsage, final JavaType type) {
+        return type.translate(NO_DECORATORS).toTypeScript(sourceUsage);
+    }
+}

--- a/packages/ts-exporter/src/test/java/org/uberfire/jsbridge/tsexporter/model/PojoTsClassTestClasses.java
+++ b/packages/ts-exporter/src/test/java/org/uberfire/jsbridge/tsexporter/model/PojoTsClassTestClasses.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter.model;
+
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+import com.google.testing.compile.CompilationRule;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.uberfire.jsbridge.tsexporter.decorators.DecoratorStore;
+import org.uberfire.jsbridge.tsexporter.decorators.ImportEntryForDecorator;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptySet;
+import static org.junit.Assert.assertEquals;
+import static org.uberfire.jsbridge.tsexporter.util.TestingUtils.init;
+import static org.uberfire.jsbridge.tsexporter.util.TestingUtils.type;
+import static org.uberfire.jsbridge.tsexporter.util.Utils.lines;
+
+public class PojoTsClassTestClasses {
+
+    @Rule
+    public final CompilationRule compilationRule = new CompilationRule();
+
+    @Before
+    public void before() {
+        init(compilationRule.getTypes(), compilationRule.getElements());
+    }
+
+    static class A {
+        private String test;
+    }
+
+    public class B extends A {
+
+        A a;
+        B b;
+        private Integer c;
+        TreeSet<String> d;
+        LinkedList<String> e;
+        TreeMap<String, String> f;
+        Optional<TreeSet<String>> g;
+    }
+
+    @Test
+    public void testNormalClass() {
+        final PojoTsClass pojoTsClass = new PojoTsClass(type(B.class), new DecoratorStore(emptySet()));
+        assertEquals(lines("",
+                           "import { Portable } from 'appformer-js';",
+                           "import { A as org_uberfire_jsbridge_tsexporter_model_PojoTsClassTestClasses_A } from '../../../../../../org/uberfire/jsbridge/tsexporter/model/PojoTsClassTestClasses/A';",
+                           "import { JavaInteger as JavaInteger } from 'appformer-js';",
+                           "import { JavaLinkedList as JavaLinkedList } from 'appformer-js';",
+                           "import { JavaOptional as JavaOptional } from 'appformer-js';",
+                           "import { JavaTreeMap as JavaTreeMap } from 'appformer-js';",
+                           "import { JavaTreeSet as JavaTreeSet } from 'appformer-js';",
+                           "",
+                           "export  class B extends org_uberfire_jsbridge_tsexporter_model_PojoTsClassTestClasses_A implements Portable<B> {",
+                           "",
+                           "  protected readonly _fqcn: string = B.__fqcn();",
+                           "",
+                           "public readonly a?: org_uberfire_jsbridge_tsexporter_model_PojoTsClassTestClasses_A = undefined;",
+                           "public readonly b?: B = undefined;",
+                           "public readonly c?: JavaInteger = undefined;",
+                           "public readonly d?: JavaTreeSet<string> = undefined;",
+                           "public readonly e?: JavaLinkedList<string> = undefined;",
+                           "public readonly f?: JavaTreeMap<string, string> = undefined;",
+                           "public readonly g?: JavaOptional<JavaTreeSet<string>> = undefined;",
+                           "",
+                           "  constructor(self: { test?: string, a?: org_uberfire_jsbridge_tsexporter_model_PojoTsClassTestClasses_A, b?: B, c?: JavaInteger, d?: JavaTreeSet<string>, e?: JavaLinkedList<string>, f?: JavaTreeMap<string, string>, g?: JavaOptional<JavaTreeSet<string>> }) {",
+                           "    super({ test: self.test });",
+                           "    Object.assign(this, self);",
+                           "  }",
+                           "",
+                           "  public static __fqcn() : string { ",
+                           "    return 'org.uberfire.jsbridge.tsexporter.model.PojoTsClassTestClasses$B'; ",
+                           "  } ",
+                           "",
+                           "}"),
+                     pojoTsClass.toSource());
+    }
+
+    public class C extends A {
+
+        A a;
+        private C c;
+        Set<A> setA;
+    }
+
+    @Test
+    public void testDecorators() {
+        final PojoTsClass pojoTsClass = new PojoTsClass(type(C.class), new DecoratorStore(new HashSet<>(asList(
+                new ImportEntryForDecorator("my-pojos", "my-decorators", "decorators/simple/CDEC", C.class.getCanonicalName()),
+                new ImportEntryForDecorator("my-pojos", "my-decorators", "decorators/simple/ADEC", A.class.getCanonicalName())
+        ))));
+
+        assertEquals(lines("",
+                           "import { Portable } from 'appformer-js';",
+                           "import { A as org_uberfire_jsbridge_tsexporter_model_PojoTsClassTestClasses_A } from '../../../../../../org/uberfire/jsbridge/tsexporter/model/PojoTsClassTestClasses/A';",
+                           "import { ADEC as decorators_simple_ADEC } from 'my-decorators';",
+                           "import { CDEC as decorators_simple_CDEC } from 'my-decorators';",
+                           "",
+                           "export  class C extends org_uberfire_jsbridge_tsexporter_model_PojoTsClassTestClasses_A implements Portable<C> {",
+                           "",
+                           "  protected readonly _fqcn: string = C.__fqcn();",
+                           "",
+                           "public readonly a?: decorators_simple_ADEC = undefined;",
+                           "public readonly c?: decorators_simple_CDEC = undefined;",
+                           "public readonly setA?: Set<decorators_simple_ADEC> = undefined;",
+                           "",
+                           "  constructor(self: { test?: string, a?: decorators_simple_ADEC, c?: decorators_simple_CDEC, setA?: Set<decorators_simple_ADEC> }) {",
+                           "    super({ test: self.test });",
+                           "    Object.assign(this, self);",
+                           "  }",
+                           "",
+                           "  public static __fqcn() : string { ",
+                           "    return 'org.uberfire.jsbridge.tsexporter.model.PojoTsClassTestClasses$C'; ",
+                           "  } ",
+                           "",
+                           "}"),
+                     pojoTsClass.toSource());
+    }
+}

--- a/packages/ts-exporter/src/test/java/org/uberfire/jsbridge/tsexporter/model/PojoTsClassTestEnum.java
+++ b/packages/ts-exporter/src/test/java/org/uberfire/jsbridge/tsexporter/model/PojoTsClassTestEnum.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter.model;
+
+import com.google.testing.compile.CompilationRule;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.uberfire.jsbridge.tsexporter.decorators.DecoratorStore.NO_DECORATORS;
+import static org.uberfire.jsbridge.tsexporter.util.TestingUtils.init;
+import static org.uberfire.jsbridge.tsexporter.util.TestingUtils.type;
+import static org.uberfire.jsbridge.tsexporter.util.Utils.lines;
+
+public class PojoTsClassTestEnum {
+
+    @Rule
+    public final CompilationRule compilationRule = new CompilationRule();
+
+    @Before
+    public void before() {
+        init(compilationRule.getTypes(), compilationRule.getElements());
+    }
+
+    enum E {
+        A,
+        B,
+        C
+    }
+
+    @Test
+    public void testEnum() {
+        final PojoTsClass pojoTsClass = new PojoTsClass(type(E.class), NO_DECORATORS);
+        assertEquals(lines("",
+                           "import { JavaEnum } from 'appformer-js';",
+                           "",
+                           "export class E extends JavaEnum<E> { ",
+                           "",
+                           "  public static readonly A:E = new E(\"A\");",
+                           "  public static readonly B:E = new E(\"B\");",
+                           "  public static readonly C:E = new E(\"C\");",
+                           "",
+                           "  protected readonly _fqcn: string = E.__fqcn();",
+                           "",
+                           "  public static __fqcn(): string {",
+                           "    return 'org.uberfire.jsbridge.tsexporter.model.PojoTsClassTestEnum$E';",
+                           "  }",
+                           "",
+                           "  public static values() {",
+                           "    return [E.A, E.B, E.C];",
+                           "  }",
+                           "}"),
+                     pojoTsClass.toSource());
+    }
+}

--- a/packages/ts-exporter/src/test/java/org/uberfire/jsbridge/tsexporter/model/PojoTsClassTestInterfaces.java
+++ b/packages/ts-exporter/src/test/java/org/uberfire/jsbridge/tsexporter/model/PojoTsClassTestInterfaces.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter.model;
+
+import com.google.testing.compile.CompilationRule;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.uberfire.jsbridge.tsexporter.meta.JavaType;
+
+import static org.junit.Assert.assertEquals;
+import static org.uberfire.jsbridge.tsexporter.decorators.DecoratorStore.NO_DECORATORS;
+import static org.uberfire.jsbridge.tsexporter.util.TestingUtils.init;
+import static org.uberfire.jsbridge.tsexporter.util.TestingUtils.type;
+import static org.uberfire.jsbridge.tsexporter.util.Utils.lines;
+
+public class PojoTsClassTestInterfaces {
+
+    @Rule
+    public final CompilationRule compilationRule = new CompilationRule();
+
+    @Before
+    public void before() {
+        init(compilationRule.getTypes(), compilationRule.getElements());
+        JavaType.SIMPLE_NAMES.set(true);
+    }
+
+    @After
+    public void after() {
+        JavaType.SIMPLE_NAMES.set(false);
+    }
+
+    interface A {
+
+    }
+
+    @Test
+    public void testInterfaceA() {
+        final PojoTsClass pojoTsClass = new PojoTsClass(type(A.class), NO_DECORATORS);
+        assertEquals(lines("",
+                           "",
+                           "",
+                           "export interface A  {",
+                           "}"),
+                     pojoTsClass.toSource());
+    }
+
+    interface B extends A {
+
+    }
+
+    @Test
+    public void testInterfaceB() {
+        final PojoTsClass pojoTsClass = new PojoTsClass(type(B.class), NO_DECORATORS);
+        assertEquals(lines("",
+                           "import { A as A } from '../../../../../../org/uberfire/jsbridge/tsexporter/model/PojoTsClassTestInterfaces/A';",
+                           "",
+                           "export interface B extends A {",
+                           "}"),
+                     pojoTsClass.toSource());
+    }
+
+    interface C<T> {
+
+    }
+
+    @Test
+    public void testInterfaceC() {
+        final PojoTsClass pojoTsClass = new PojoTsClass(type(C.class), NO_DECORATORS);
+        assertEquals(lines("",
+                           "",
+                           "",
+                           "export interface C<T>  {",
+                           "}"),
+                     pojoTsClass.toSource());
+    }
+
+    interface D<T extends A> {
+
+    }
+
+    @Test
+    public void testInterfaceD() {
+        final PojoTsClass pojoTsClass = new PojoTsClass(type(D.class), NO_DECORATORS);
+        assertEquals(lines("",
+                           "import { A as A } from '../../../../../../org/uberfire/jsbridge/tsexporter/model/PojoTsClassTestInterfaces/A';",
+                           "",
+                           "export interface D<T extends A>  {",
+                           "}"),
+                     pojoTsClass.toSource());
+    }
+
+    interface E<J extends D<A>> {
+
+    }
+
+    @Test
+    public void testInterfaceE() {
+        final PojoTsClass pojoTsClass = new PojoTsClass(type(E.class), NO_DECORATORS);
+        assertEquals(lines("",
+                           "import { A as A } from '../../../../../../org/uberfire/jsbridge/tsexporter/model/PojoTsClassTestInterfaces/A';",
+                           "import { D as D } from '../../../../../../org/uberfire/jsbridge/tsexporter/model/PojoTsClassTestInterfaces/D';",
+                           "",
+                           "export interface E<J extends D<A>>  {",
+                           "}"),
+                     pojoTsClass.toSource());
+    }
+
+    interface F<B extends F<?>> {
+
+    }
+
+    @Test
+    public void testInterfaceF() {
+        final PojoTsClass pojoTsClass = new PojoTsClass(type(F.class), NO_DECORATORS);
+        assertEquals(lines("",
+                           "",
+                           "",
+                           "export interface F<B extends F<any /* wildcard */>>  {",
+                           "}"),
+                     pojoTsClass.toSource());
+    }
+
+    interface G<T> extends A {
+
+    }
+
+    @Test
+    public void testInterfaceG() {
+        final PojoTsClass pojoTsClass = new PojoTsClass(type(G.class), NO_DECORATORS);
+        assertEquals(lines("",
+                           "import { A as A } from '../../../../../../org/uberfire/jsbridge/tsexporter/model/PojoTsClassTestInterfaces/A';",
+                           "",
+                           "export interface G<T> extends A {",
+                           "}"),
+                     pojoTsClass.toSource());
+    }
+
+    interface H<T> extends C<T> {
+
+    }
+
+    @Test
+    public void testInterfaceH() {
+        final PojoTsClass pojoTsClass = new PojoTsClass(type(H.class), NO_DECORATORS);
+        assertEquals(lines("",
+                           "import { C as C } from '../../../../../../org/uberfire/jsbridge/tsexporter/model/PojoTsClassTestInterfaces/C';",
+                           "",
+                           "export interface H<T> extends C<T> {",
+                           "}"),
+                     pojoTsClass.toSource());
+    }
+
+    interface I<T extends C<I>> extends H<T> {
+
+    }
+
+    @Test
+    public void testInterfaceI() {
+        final PojoTsClass pojoTsClass = new PojoTsClass(type(I.class), NO_DECORATORS);
+        assertEquals(lines("",
+                           "import { C as C } from '../../../../../../org/uberfire/jsbridge/tsexporter/model/PojoTsClassTestInterfaces/C';",
+                           "import { H as H } from '../../../../../../org/uberfire/jsbridge/tsexporter/model/PojoTsClassTestInterfaces/H';",
+                           "",
+                           "export interface I<T extends C<I<any>>> extends H<T> {",
+                           "}"),
+                     pojoTsClass.toSource());
+    }
+}

--- a/packages/ts-exporter/src/test/java/org/uberfire/jsbridge/tsexporter/model/RpcCallerTsClassTest.java
+++ b/packages/ts-exporter/src/test/java/org/uberfire/jsbridge/tsexporter/model/RpcCallerTsClassTest.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter.model;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.stream.Stream;
+
+import com.google.testing.compile.CompilationRule;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.uberfire.jsbridge.tsexporter.decorators.DecoratorStore;
+import org.uberfire.jsbridge.tsexporter.decorators.ImportEntryForDecorator;
+import org.uberfire.jsbridge.tsexporter.dependency.DependencyGraph;
+import org.uberfire.jsbridge.tsexporter.meta.JavaType;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.uberfire.jsbridge.tsexporter.decorators.DecoratorStore.NO_DECORATORS;
+import static org.uberfire.jsbridge.tsexporter.util.TestingUtils.element;
+import static org.uberfire.jsbridge.tsexporter.util.TestingUtils.init;
+import static org.uberfire.jsbridge.tsexporter.util.Utils.lines;
+
+public class RpcCallerTsClassTest {
+
+    @Rule
+    public final CompilationRule compilationRule = new CompilationRule();
+
+    @Before
+    public void before() {
+        init(compilationRule.getTypes(), compilationRule.getElements());
+        JavaType.SIMPLE_NAMES.set(false);
+    }
+
+    @After
+    public void after() {
+        JavaType.SIMPLE_NAMES.set(false);
+    }
+
+    interface Foo<T> {
+
+    }
+
+    class FooImpl1<T> implements Foo<T> {
+
+        String foo;
+    }
+
+    class FooImpl2 extends FooImpl1<String> {
+
+        String bar;
+    }
+
+    interface SomeInterface {
+
+        Foo<String> someMethod();
+    }
+
+    @Test
+    public void testDecorators() {
+
+        final DependencyGraph dependencyGraph = new DependencyGraph(Stream.of(element(FooImpl2.class)),
+                                                                    NO_DECORATORS);
+
+        final RpcCallerTsClass tsClass = new RpcCallerTsClass(
+                element(SomeInterface.class),
+                dependencyGraph,
+                new DecoratorStore(new HashSet<>(asList(
+                        new ImportEntryForDecorator("my-pojos", "my-decorators", "decorators/pojo/FooDEC", Foo.class.getCanonicalName()),
+                        new ImportEntryForDecorator("my-pojos", "my-decorators", "decorators/pojo/impl/FooImpl1DEC", FooImpl1.class.getCanonicalName()),
+                        new ImportEntryForDecorator("my-pojos", "my-decorators", "decorators/pojo/impl/FooImpl2DEC", FooImpl2.class.getCanonicalName()))
+                )));
+
+        assertEquals(
+                lines("",
+                      "import { rpc, marshall, unmarshall } from 'appformer-js';",
+                      "import { FooDEC as decorators_pojo_FooDEC } from 'my-decorators';",
+                      "import { FooImpl1DEC as decorators_pojo_impl_FooImpl1DEC } from 'my-decorators';",
+                      "import { FooImpl2DEC as decorators_pojo_impl_FooImpl2DEC } from 'my-decorators';",
+                      "",
+                      "export class SomeInterface {",
+                      "",
+                      "public someMethod(args: {  }) {",
+                      "  return rpc(\"org.uberfire.jsbridge.tsexporter.model.RpcCallerTsClassTest.SomeInterface|someMethod:\", [])",
+                      "         .then((json: string) => {",
+                      "           return unmarshall(json, new Map([",
+                      "[\"org.uberfire.jsbridge.tsexporter.model.RpcCallerTsClassTest$FooImpl1\", () => new decorators_pojo_impl_FooImpl1DEC<any>({  }) as any],",
+                      "[\"org.uberfire.jsbridge.tsexporter.model.RpcCallerTsClassTest$FooImpl2\", () => new decorators_pojo_impl_FooImpl2DEC({  }) as any]",
+                      "           ])) as decorators_pojo_FooDEC<string>;",
+                      "         });",
+                      "}",
+                      "",
+                      "}"),
+                tsClass.toSource());
+    }
+
+    class FooImpl3 {
+
+        FooImpl1 fooImpl1;
+        FooImpl2 fooImpl2;
+    }
+
+    interface SomeOtherInterface {
+
+        List<FooImpl3> someMethod();
+    }
+
+    @Test
+    public void testDecoratorsIndirectly() {
+
+        final DependencyGraph dependencyGraph = new DependencyGraph(Stream.of(element(FooImpl3.class)),
+                                                                    NO_DECORATORS);
+
+        final RpcCallerTsClass tsClass = new RpcCallerTsClass(
+                element(SomeOtherInterface.class),
+                dependencyGraph,
+                new DecoratorStore(new HashSet<>(asList(
+                        new ImportEntryForDecorator("my-pojos", "my-decorators", "decorators/pojo/FooDEC", Foo.class.getCanonicalName()),
+                        new ImportEntryForDecorator("my-pojos", "my-decorators", "decorators/pojo/impl/FooImpl1DEC", FooImpl1.class.getCanonicalName()),
+                        new ImportEntryForDecorator("my-pojos", "my-decorators", "decorators/pojo/impl/FooImpl2DEC", FooImpl2.class.getCanonicalName())
+                ))));
+
+        assertEquals(
+                lines("",
+                      "import { rpc, marshall, unmarshall } from 'appformer-js';",
+                      "import { FooImpl1DEC as decorators_pojo_impl_FooImpl1DEC } from 'my-decorators';",
+                      "import { FooImpl2DEC as decorators_pojo_impl_FooImpl2DEC } from 'my-decorators';",
+                      "import { FooImpl3 as org_uberfire_jsbridge_tsexporter_model_RpcCallerTsClassTest_FooImpl3 } from '@kiegroup-ts-generated/ts-exporter-test';",
+                      "",
+                      "export class SomeOtherInterface {",
+                      "",
+                      "public someMethod(args: {  }) {",
+                      "  return rpc(\"org.uberfire.jsbridge.tsexporter.model.RpcCallerTsClassTest.SomeOtherInterface|someMethod:\", [])",
+                      "         .then((json: string) => {",
+                      "           return unmarshall(json, new Map([",
+                      "[\"org.uberfire.jsbridge.tsexporter.model.RpcCallerTsClassTest$FooImpl1\", () => new decorators_pojo_impl_FooImpl1DEC<any>({  }) as any],",
+                      "[\"org.uberfire.jsbridge.tsexporter.model.RpcCallerTsClassTest$FooImpl2\", () => new decorators_pojo_impl_FooImpl2DEC({  }) as any],",
+                      "[\"org.uberfire.jsbridge.tsexporter.model.RpcCallerTsClassTest$FooImpl3\", () => new org_uberfire_jsbridge_tsexporter_model_RpcCallerTsClassTest_FooImpl3({  }) as any]",
+                      "           ])) as Array<org_uberfire_jsbridge_tsexporter_model_RpcCallerTsClassTest_FooImpl3>;",
+                      "         });",
+                      "}",
+                      "",
+                      "}"),
+                tsClass.toSource());
+    }
+
+    enum BarType {
+        BAR1,
+        BAR2,
+        BAR3
+    }
+
+    class FooImpl4 {
+
+        FooImpl1 fooImpl1;
+        BarType barType;
+    }
+
+    interface SomeOtherInterfaceOnceAgain {
+
+        List<FooImpl4> someMethod();
+    }
+
+    @Test
+    public void testEnumFactory() {
+
+        final DependencyGraph dependencyGraph = new DependencyGraph(Stream.of(element(FooImpl3.class)),
+                                                                    NO_DECORATORS);
+
+        final RpcCallerTsClass tsClass = new RpcCallerTsClass(
+                element(SomeOtherInterfaceOnceAgain.class),
+                dependencyGraph,
+                NO_DECORATORS);
+
+        assertEquals(
+                lines("",
+                      "import { rpc, marshall, unmarshall } from 'appformer-js';",
+                      "import { BarType as org_uberfire_jsbridge_tsexporter_model_RpcCallerTsClassTest_BarType } from '@kiegroup-ts-generated/ts-exporter-test';",
+                      "import { FooImpl1 as org_uberfire_jsbridge_tsexporter_model_RpcCallerTsClassTest_FooImpl1 } from '@kiegroup-ts-generated/ts-exporter-test';",
+                      "import { FooImpl2 as org_uberfire_jsbridge_tsexporter_model_RpcCallerTsClassTest_FooImpl2 } from '@kiegroup-ts-generated/ts-exporter-test';",
+                      "import { FooImpl4 as org_uberfire_jsbridge_tsexporter_model_RpcCallerTsClassTest_FooImpl4 } from '@kiegroup-ts-generated/ts-exporter-test';",
+                      "",
+                      "export class SomeOtherInterfaceOnceAgain {",
+                      "",
+                      "public someMethod(args: {  }) {",
+                      "  return rpc(\"org.uberfire.jsbridge.tsexporter.model.RpcCallerTsClassTest.SomeOtherInterfaceOnceAgain|someMethod:\", [])",
+                      "         .then((json: string) => {",
+                      "           return unmarshall(json, new Map([",
+                      "[\"org.uberfire.jsbridge.tsexporter.model.RpcCallerTsClassTest$BarType\", ((name: string) => { switch (name) { case \"BAR1\": return org_uberfire_jsbridge_tsexporter_model_RpcCallerTsClassTest_BarType.BAR1; case \"BAR2\": return org_uberfire_jsbridge_tsexporter_model_RpcCallerTsClassTest_BarType.BAR2; case \"BAR3\": return org_uberfire_jsbridge_tsexporter_model_RpcCallerTsClassTest_BarType.BAR3; default: throw new Error(`Unknown value ${name} for enum org_uberfire_jsbridge_tsexporter_model_RpcCallerTsClassTest_BarType!`); }}) as any],",
+                      "[\"org.uberfire.jsbridge.tsexporter.model.RpcCallerTsClassTest$FooImpl1\", () => new org_uberfire_jsbridge_tsexporter_model_RpcCallerTsClassTest_FooImpl1<any>({  }) as any],",
+                      "[\"org.uberfire.jsbridge.tsexporter.model.RpcCallerTsClassTest$FooImpl2\", () => new org_uberfire_jsbridge_tsexporter_model_RpcCallerTsClassTest_FooImpl2({  }) as any],",
+                      "[\"org.uberfire.jsbridge.tsexporter.model.RpcCallerTsClassTest$FooImpl4\", () => new org_uberfire_jsbridge_tsexporter_model_RpcCallerTsClassTest_FooImpl4({  }) as any]",
+                      "           ])) as Array<org_uberfire_jsbridge_tsexporter_model_RpcCallerTsClassTest_FooImpl4>;",
+                      "         });",
+                      "}",
+                      "",
+                      "}"),
+                tsClass.toSource());
+    }
+}

--- a/packages/ts-exporter/src/test/java/org/uberfire/jsbridge/tsexporter/util/TestingUtils.java
+++ b/packages/ts-exporter/src/test/java/org/uberfire/jsbridge/tsexporter/util/TestingUtils.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.jsbridge.tsexporter.util;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.ArrayType;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.ExecutableType;
+import javax.lang.model.type.PrimitiveType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.type.WildcardType;
+import javax.lang.model.util.Elements;
+import javax.lang.model.util.Types;
+
+import org.uberfire.jsbridge.tsexporter.Main;
+import org.uberfire.jsbridge.tsexporter.meta.JavaType;
+
+import static java.util.stream.Collectors.toList;
+
+public class TestingUtils {
+
+    public static Types types;
+    public static Elements elements;
+
+    public static void init(final Types types, final Elements elements) {
+        TestingUtils.types = Main.types = types;
+        TestingUtils.elements = Main.elements = elements;
+    }
+
+    public static WildcardType wildcard(final TypeMirror extendsBound, final TypeMirror superBound) {
+        return types.getWildcardType(extendsBound, superBound);
+    }
+
+    public static PrimitiveType primitive(final TypeKind kind) {
+        return types.getPrimitiveType(kind);
+    }
+
+    public static ArrayType array(final TypeMirror type) {
+        return types.getArrayType(type);
+    }
+
+    public static TypeMirror erased(final TypeMirror type) {
+        return types.erasure(type);
+    }
+
+    public static DeclaredType type(final Class<?> clazz) {
+        return (DeclaredType) elements.getTypeElement(clazz.getCanonicalName()).asType();
+    }
+
+    public static TypeElement element(final Class<?> clazz) {
+        return elements.getTypeElement(clazz.getCanonicalName());
+    }
+
+    public static JavaType member(final String name, final TypeMirror owner) {
+        return new JavaType(memberElement(name, owner).asType(), owner);
+    }
+
+    public static Element memberElement(final String name, final TypeMirror owner) {
+        return elements.getAllMembers((TypeElement) types.asElement(owner)).stream()
+                .filter(s -> s.getSimpleName().toString().equals(name))
+                .collect(toList())
+                .get(0);
+    }
+
+    public static JavaType param(final int i, final JavaType owner) {
+        return new JavaType(((ExecutableType) owner.getType()).getParameterTypes().get(i), owner.getOwner());
+    }
+
+    public static class Foo {
+
+        public static class Bar {
+
+        }
+    }
+
+    public abstract static class DeclaredTypes {
+
+        Map<String, String> map;
+        TreeMap<String, String> treeMap;
+        List<String> list;
+        ArrayList<String> arrayList;
+        LinkedList<String> linkedList;
+        Set<String> set;
+        HashSet<String> hashSet;
+        TreeSet<String> treeSet;
+        Collection<String> collection;
+        Class<String> clazz;
+        Optional<String> optional;
+    }
+
+    public abstract static class Circle<T extends Circle<T>> {
+
+        T field1;
+        Circle<T> field2;
+
+        abstract void get1(T t);
+
+        abstract <U> void get2(T t, U u);
+
+        abstract <U extends T> void get3(T t, U u);
+
+        abstract <U extends T, S extends U> void get4(T t, U u, S s);
+
+        abstract <U extends T, S extends List<? extends T>> void get5(T t, U u, S s);
+
+        abstract <U extends T, S extends Circle<T>> void get6(T t, U u, S s);
+
+        abstract <U extends T, S extends Circle<T>> void get7(T t, U u, S s);
+    }
+
+    public abstract static class Cylinder extends Circle<Cylinder> {
+
+    }
+
+    public abstract static class Sphere<J> extends Circle<Sphere<J>> {
+
+    }
+}


### PR DESCRIPTION
This PR adds the ts-exporter Java Annotation Processor. It's used to generate a TypeScript API from the annotated Java `@Remote` and `@Portable` classes. By adding its jar to the classpath during compilation, it will generate and locally publish the npm packages containing the TypeScript RPC API.

Further info about this module will be added on its own README.md file later on this same PR.